### PR TITLE
Screen Titles

### DIFF
--- a/publicmeetings-ios/AppDelegate.swift
+++ b/publicmeetings-ios/AppDelegate.swift
@@ -11,8 +11,6 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -14,18 +14,16 @@ class MeetingsViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .systemIndigo
-        self.tabBarController?.navigationItem.title = "Meetings"
+        setScreenTitle()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewWillAppear(_ animated: Bool) {
+        setScreenTitle()
     }
-    */
-
+    
+    func setScreenTitle() {
+        DispatchQueue.main.async {
+            self.tabBarController?.navigationItem.title = "Meetings"
+        }
+    }
 }

--- a/publicmeetings-ios/Controllers/MoreViewController.swift
+++ b/publicmeetings-ios/Controllers/MoreViewController.swift
@@ -14,18 +14,18 @@ class MoreViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .systemTeal
-        self.tabBarController?.navigationItem.title = "More"
+        setScreenTitle()
+
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewWillAppear(_ animated: Bool) {
+        setScreenTitle()
     }
-    */
-
+    
+    func setScreenTitle() {
+        DispatchQueue.main.async {
+            self.tabBarController?.navigationItem.title = "More"
+        }
+    }
+    
 }

--- a/publicmeetings-ios/SceneDelegate.swift
+++ b/publicmeetings-ios/SceneDelegate.swift
@@ -13,7 +13,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     var navigationController: UINavigationController?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.

--- a/publicmeetings-ios/TabBar/TabBarController.swift
+++ b/publicmeetings-ios/TabBar/TabBarController.swift
@@ -21,7 +21,6 @@ class TabBarController: UITabBarController {
         
          meetingsViewController.navigationController?.navigationBar.topItem?.title = "Meetings"
          moreViewController.navigationController?.navigationBar.topItem?.title = "More"
-
          
          let viewControllerList = [meetingsViewController, moreViewController]
          viewControllers = viewControllerList


### PR DESCRIPTION
Set the navigation bar title when the user changes from one
screen to the other.  Keep the nav title in sync with the
tab title.

TODO: As we define the tab screens, have one delegate method
to use for setting the title.

Changes to be committed:
	modified:   publicmeetings-ios/AppDelegate.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/Controllers/MoreViewController.swift
	modified:   publicmeetings-ios/SceneDelegate.swift
	modified:   publicmeetings-ios/TabBar/TabBarController.swift