### PR TITLE
Color assets

### DIFF
--- a/publicmeetings-ios.xcodeproj/project.pbxproj
+++ b/publicmeetings-ios.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		E54DA379234431E70070241F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E54DA377234431E70070241F /* LaunchScreen.storyboard */; };
 		E54DA384234431E70070241F /* publicmeetings_iosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54DA383234431E70070241F /* publicmeetings_iosTests.swift */; };
 		E54DA38F234431E70070241F /* publicmeetings_iosUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54DA38E234431E70070241F /* publicmeetings_iosUITests.swift */; };
+		E55F53B723462E2700200F10 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E55F53B623462E2700200F10 /* Colors.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +60,7 @@
 		E54DA38A234431E70070241F /* publicmeetings-iosUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "publicmeetings-iosUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E54DA38E234431E70070241F /* publicmeetings_iosUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = publicmeetings_iosUITests.swift; sourceTree = "<group>"; };
 		E54DA390234431E70070241F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E55F53B623462E2700200F10 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,6 +153,7 @@
 				E54DA36E234431E60070241F /* SceneDelegate.swift */,
 				E54DA370234431E60070241F /* ViewController.swift */,
 				E54DA375234431E70070241F /* Assets.xcassets */,
+				E55F53B623462E2700200F10 /* Colors.xcassets */,
 				E54DA377234431E70070241F /* LaunchScreen.storyboard */,
 				E54DA37A234431E70070241F /* Info.plist */,
 			);
@@ -279,6 +282,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E55F53B723462E2700200F10 /* Colors.xcassets in Resources */,
 				E54DA379234431E70070241F /* LaunchScreen.storyboard in Resources */,
 				E54DA376234431E70070241F /* Assets.xcassets in Resources */,
 			);

--- a/publicmeetings-ios/Colors.xcassets/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/publicmeetings-ios/Colors.xcassets/devictOrange.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/devictOrange.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.890",
+          "alpha" : "1.000",
+          "blue" : "0.082",
+          "green" : "0.549"
+        }
+      }
+    }
+  ]
+}

--- a/publicmeetings-ios/Colors.xcassets/devictTan.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/devictTan.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.921",
+          "alpha" : "1.000",
+          "blue" : "0.882",
+          "green" : "0.913"
+        }
+      }
+    }
+  ]
+}

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -10,17 +10,19 @@ import UIKit
 
 class MeetingsViewController: UIViewController {
 
+    //MARK: - Properties
     var meetingsView: MeetingsView = {
         let view = MeetingsView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .systemOrange
+        view.backgroundColor = UIColor(named: "devictOrange")
         return view
     }()
         
+    //MARK: - Delegates
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .systemGray3
+        view.backgroundColor = UIColor(named: "devictTan")
         setScreenTitle()
         
         setupView()
@@ -31,6 +33,7 @@ class MeetingsViewController: UIViewController {
         setScreenTitle()
     }
     
+    //MARK: - Methods
     func setScreenTitle() {
         DispatchQueue.main.async {
             self.tabBarController?.navigationItem.title = "Meetings"

--- a/publicmeetings-ios/SceneDelegate.swift
+++ b/publicmeetings-ios/SceneDelegate.swift
@@ -18,8 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        
-        
+                
         let rootViewController = TabBarController()
         navigationController = UINavigationController()
         navigationController?.viewControllers = [rootViewController]

--- a/publicmeetings-ios/Views/MeetingsView.swift
+++ b/publicmeetings-ios/Views/MeetingsView.swift
@@ -15,7 +15,6 @@ class MeetingsView: UIView {
            let segmented = UISegmentedControl(items: ["Wichita","County", "State"])
            segmented.translatesAutoresizingMaskIntoConstraints = false
            segmented.backgroundColor = .clear
-           segmented.tintColor = .systemOrange
            segmented.selectedSegmentIndex = 0
            return segmented
     }()


### PR DESCRIPTION
Create Colors.xcassets
Define the following colors:
    devictOrange: RGB(227, 140, 21)
    devictTan: RGB(235, 233, 225)

Change existing colors to use these.

Changes to be committed:
	modified:   publicmeetings-ios.xcodeproj/project.pbxproj
	new file:   publicmeetings-ios/Colors.xcassets/Contents.json
	new file:   publicmeetings-ios/Colors.xcassets/devictOrange.colorset/Contents.json
	new file:   publicmeetings-ios/Colors.xcassets/devictTan.colorset/Contents.json
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/SceneDelegate.swift
	modified:   publicmeetings-ios/Views/MeetingsView.swift