### PR TITLE
Symbol Configuration

### DIFF
--- a/publicmeetings-ios/TabBar/TabBarController.swift
+++ b/publicmeetings-ios/TabBar/TabBarController.swift
@@ -16,8 +16,9 @@ class TabBarController: UITabBarController {
         let meetingsViewController = MeetingsViewController()
         let moreViewController = MoreViewController()
          
-        let meetingImage = UIImage(systemName: "calendar")
-        let moreImage = UIImage(systemName: "ellipsis.circle")
+        let config = UIImage.SymbolConfiguration(weight: .heavy)
+        let meetingImage = UIImage(systemName: "calendar", withConfiguration: config)
+        let moreImage = UIImage(systemName: "ellipsis.circle", withConfiguration: config)
         
         meetingsViewController.tabBarItem = UITabBarItem(title: "Meetings", image: meetingImage, selectedImage: meetingImage)
         moreViewController.tabBarItem = UITabBarItem(title: "More", image: moreImage, selectedImage: moreImage)


### PR DESCRIPTION
Change the symbol configuration for the tab bar icons so they
stand out more.  Set the configuration to .heavy.

Changes to be committed:
	modified:   publicmeetings-ios/TabBar/TabBarController.swift