### PR TITLE
Color Changes

### DIFF
--- a/publicmeetings-ios/Colors.xcassets/burntOrange.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/burntOrange.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xE2",
+          "red" : "0.768",
           "alpha" : "1.000",
-          "blue" : "0x14",
-          "green" : "0x8B"
+          "blue" : "0.231",
+          "green" : "0.392"
         }
       }
     }

--- a/publicmeetings-ios/Colors.xcassets/devictBlue.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/devictBlue.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xE2",
+          "red" : "0x20",
           "alpha" : "1.000",
-          "blue" : "0x14",
-          "green" : "0x8B"
+          "blue" : "0xDF",
+          "green" : "0x6D"
         }
       }
     }

--- a/publicmeetings-ios/Colors.xcassets/devictSpringGreen.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/devictSpringGreen.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xE2",
+          "red" : "0xAB",
           "alpha" : "1.000",
-          "blue" : "0x14",
-          "green" : "0x8B"
+          "blue" : "0x36",
+          "green" : "0xC9"
         }
       }
     }

--- a/publicmeetings-ios/Colors.xcassets/orangeWhip.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/orangeWhip.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xE2",
+          "red" : "0xDE",
           "alpha" : "1.000",
-          "blue" : "0x14",
-          "green" : "0x8B"
+          "blue" : "0x21",
+          "green" : "0x91"
         }
       }
     }

--- a/publicmeetings-ios/Colors.xcassets/papayaWhip.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/papayaWhip.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xE2",
+          "red" : "1.000",
           "alpha" : "1.000",
-          "blue" : "0x14",
-          "green" : "0x8B"
+          "blue" : "0.835",
+          "green" : "0.937"
         }
       }
     }

--- a/publicmeetings-ios/Colors.xcassets/softBlue.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/softBlue.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xE2",
+          "red" : "0.231",
           "alpha" : "1.000",
-          "blue" : "0x14",
-          "green" : "0x8B"
+          "blue" : "0.768",
+          "green" : "0.607"
         }
       }
     }

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -14,14 +14,14 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     var meetingLocality: UISegmentedControl = {
         let segmented = UISegmentedControl(items: ["Wichita", "County", "State"])
         segmented.translatesAutoresizingMaskIntoConstraints = false
-        segmented.backgroundColor = UIColor(named: "devictOrange")
+        segmented.backgroundColor = UIColor(named: "devictSpringGreen")
         segmented.selectedSegmentIndex = 0
         return segmented
     }()
     
     var tableView = UITableView()
     
-    var names: [String] = ["First","Second","Third","Fourth","Fifth"]
+    var names: [String] = ["First","Second","Third","Fourth","Fifth","Sixth","Seventh"]
     
     //MARK: - ViewController Delegates
     override func viewDidLoad() {
@@ -44,8 +44,10 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell") as! MeetingCell
         let row = indexPath.row
+        let backColor = indexPath.row % 2 == 0 ? .white : UIColor(named: "papayaWhip")
         
-        cell.backgroundColor = UIColor(named: "devictTan")
+        cell.accessoryType = .disclosureIndicator
+        cell.backgroundColor = backColor
         cell.name.text = names[row]
         return cell
     }
@@ -70,6 +72,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(MeetingCell.self, forCellReuseIdentifier: "cell")
+        tableView.tableFooterView = UIView()
     }
     
     private func setupLayout() {

--- a/publicmeetings-ios/SceneDelegate.swift
+++ b/publicmeetings-ios/SceneDelegate.swift
@@ -22,6 +22,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let rootViewController = TabBarController()
         navigationController = UINavigationController()
         navigationController?.viewControllers = [rootViewController]
+        navigationController?.navigationBar.barTintColor = UIColor(named: "devictBlue")
+        UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.foregroundColor : UIColor.white]
         
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene


### PR DESCRIPTION
Add additional colors to Colors.xcassets.

Experimented with different color schemes.  The
chosen colors are for demonstrations purposes
only and are guaranteed to change as the design
team gets more involved.

Changes to be committed:
	new file:   publicmeetings-ios/Colors.xcassets/burntOrange.colorset/Contents.json
	new file:   publicmeetings-ios/Colors.xcassets/devictBlue.colorset/Contents.json
	modified:   publicmeetings-ios/Colors.xcassets/devictOrange.colorset/Contents.json
	new file:   publicmeetings-ios/Colors.xcassets/devictSpringGreen.colorset/Contents.json
	new file:   publicmeetings-ios/Colors.xcassets/orangeWhip.colorset/Contents.json
	new file:   publicmeetings-ios/Colors.xcassets/papayaWhip.colorset/Contents.json
	new file:   publicmeetings-ios/Colors.xcassets/softBlue.colorset/Contents.json
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/SceneDelegate.swift