### PR TITLE
Meeting Detail

### DIFF
--- a/publicmeetings-ios.xcodeproj/project.pbxproj
+++ b/publicmeetings-ios.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E511CFEA234A8D4800807CAF /* MeetingsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E511CFE9234A8D4800807CAF /* MeetingsDetailView.swift */; };
+		E511CFEE234A8EE700807CAF /* Accuracy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E511CFEC234A8EE700807CAF /* Accuracy.swift */; };
+		E511CFEF234A8EE700807CAF /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E511CFED234A8EE700807CAF /* Screen.swift */; };
+		E511CFF1234A8FC300807CAF /* MeetingsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E511CFF0234A8FC300807CAF /* MeetingsDetailViewController.swift */; };
 		E512C19A23445A29005BF52E /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = E512C19923445A29005BF52E /* User.swift */; };
 		E512C19D23445BD6005BF52E /* Meeting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E512C19C23445BD6005BF52E /* Meeting.swift */; };
 		E514FAAC2347330D00075816 /* MeetingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E514FAAB2347330D00075816 /* MeetingCell.swift */; };
@@ -42,6 +46,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		E511CFE9234A8D4800807CAF /* MeetingsDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingsDetailView.swift; sourceTree = "<group>"; };
+		E511CFEC234A8EE700807CAF /* Accuracy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Accuracy.swift; sourceTree = "<group>"; };
+		E511CFED234A8EE700807CAF /* Screen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
+		E511CFF0234A8FC300807CAF /* MeetingsDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingsDetailViewController.swift; sourceTree = "<group>"; };
 		E512C19923445A29005BF52E /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		E512C19C23445BD6005BF52E /* Meeting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Meeting.swift; sourceTree = "<group>"; };
 		E514FAAB2347330D00075816 /* MeetingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCell.swift; sourceTree = "<group>"; };
@@ -90,6 +98,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		E511CFE8234A8D3000807CAF /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				E511CFE9234A8D4800807CAF /* MeetingsDetailView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		E511CFEB234A8EB100807CAF /* Constants */ = {
+			isa = PBXGroup;
+			children = (
+				E511CFEC234A8EE700807CAF /* Accuracy.swift */,
+				E511CFED234A8EE700807CAF /* Screen.swift */,
+			);
+			path = Constants;
+			sourceTree = "<group>";
+		};
 		E512C19B23445A31005BF52E /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -116,17 +141,11 @@
 			path = TabBar;
 			sourceTree = "<group>";
 		};
-		E51FA4A82344E297005C5091 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
 		E51FA4A92344E2A7005C5091 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
 				E52E43D923485B3600DF9D5B /* MeetingsViewController.swift */,
+				E511CFF0234A8FC300807CAF /* MeetingsDetailViewController.swift */,
 				E52E43D5234854CA00DF9D5B /* MoreViewController.swift */,
 			);
 			path = Controllers;
@@ -163,9 +182,10 @@
 		E54DA36B234431E60070241F /* publicmeetings-ios */ = {
 			isa = PBXGroup;
 			children = (
+				E511CFEB234A8EB100807CAF /* Constants */,
+				E511CFE8234A8D3000807CAF /* Views */,
 				E51FA4A52344DF88005C5091 /* TabBar */,
 				E512C19B23445A31005BF52E /* Models */,
-				E51FA4A82344E297005C5091 /* Views */,
 				E51FA4A92344E2A7005C5091 /* Controllers */,
 				E514FAAA234732E500075816 /* Cells */,
 				E525261723490A150003B575 /* Assets */,
@@ -332,12 +352,16 @@
 				E512C19D23445BD6005BF52E /* Meeting.swift in Sources */,
 				E512C19A23445A29005BF52E /* User.swift in Sources */,
 				E52E43DA23485B3600DF9D5B /* MeetingsViewController.swift in Sources */,
+				E511CFEA234A8D4800807CAF /* MeetingsDetailView.swift in Sources */,
 				E54DA36D234431E60070241F /* AppDelegate.swift in Sources */,
+				E511CFEE234A8EE700807CAF /* Accuracy.swift in Sources */,
+				E511CFF1234A8FC300807CAF /* MeetingsDetailViewController.swift in Sources */,
 				E51FA4A72344DFF6005C5091 /* TabBarController.swift in Sources */,
 				E52E43D6234854CA00DF9D5B /* MoreViewController.swift in Sources */,
 				E54DA36F234431E60070241F /* SceneDelegate.swift in Sources */,
 				E514FAAC2347330D00075816 /* MeetingCell.swift in Sources */,
 				E525261B234911070003B575 /* MoreCell.swift in Sources */,
+				E511CFEF234A8EE700807CAF /* Screen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -30,14 +30,13 @@ class MeetingCell: UITableViewCell {
     }()
     
     //MARK: - Initialization
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
         setupView()
         setupLayout()
-        
-        reminder.addTarget(self, action: #selector(reminderTapped(sender:)), for: .touchUpInside)
-        
+        setupActions()
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -73,6 +72,11 @@ class MeetingCell: UITableViewCell {
         ])
     }
     
+    private func setupActions() {
+        reminder.addTarget(self, action: #selector(reminderTapped(sender:)), for: .touchUpInside)
+    }
+        
+    //MARK: - Actions
     @objc func reminderTapped(sender: UIButton) {
         guard let name = name.text else { return }
         print("\(name) button tapped")

--- a/publicmeetings-ios/Cells/MoreCell.swift
+++ b/publicmeetings-ios/Cells/MoreCell.swift
@@ -16,8 +16,6 @@ class MoreCell: UITableViewCell {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = .black
         label.textAlignment = .left
-        label.numberOfLines = 2
-        label.lineBreakMode = .byWordWrapping
         return label
     }()
     

--- a/publicmeetings-ios/Constants/Accuracy.swift
+++ b/publicmeetings-ios/Constants/Accuracy.swift
@@ -1,0 +1,13 @@
+//
+//  Accuracy.swift
+//  CarClub
+//
+//  Created by mpc on 8/14/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import Foundation
+
+struct Distance {
+    static let standard: Double  = 1000.0
+}

--- a/publicmeetings-ios/Constants/Screen.swift
+++ b/publicmeetings-ios/Constants/Screen.swift
@@ -1,0 +1,16 @@
+//
+//  Screen.swift
+//  CarClub
+//
+//  Created by mpc on 8/11/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+struct Screen {
+    static let screenSize = UIScreen.main.bounds
+    static let width = screenSize.width
+    static let height = screenSize.height
+    static let scale = UIScreen.main.scale
+}

--- a/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
@@ -1,0 +1,43 @@
+//
+//  MeetingsDetailViewController.swift
+//  publicmeetings-ios
+//
+//  Created by mpc on 10/6/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+class MeetingsDetailViewController: UIViewController {
+
+    var meetingsDetail: MeetingsDetailView = {
+        var map = MeetingsDetailView()
+        map.translatesAutoresizingMaskIntoConstraints = false
+        return map
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .systemGray6
+        
+        setupView()
+        setupLayout()
+    }
+    
+    //MARK: - Setup and Layout
+    func setupView() {
+        view.addSubview(meetingsDetail)
+    }
+    
+    func setupLayout() {
+        NSLayoutConstraint.activate([
+            meetingsDetail.topAnchor.constraint(equalTo: view.topAnchor),
+            meetingsDetail.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            meetingsDetail.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            meetingsDetail.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            meetingsDetail.heightAnchor.constraint(equalToConstant: view.frame.height),
+            meetingsDetail.widthAnchor.constraint(equalToConstant: view.frame.width)
+        ])
+    }
+}

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -27,6 +27,10 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        //Temporary - Proof of concept only
+        tabBarController?.tabBar.items?[0].badgeColor = UIColor(named: "devictBlue")
+        tabBarController?.tabBar.items?[0].badgeValue = "3"
+
         setupView()
         setupLayout()
         setScreenTitle()
@@ -44,7 +48,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell") as! MeetingCell
         let row = indexPath.row
-        let backColor = indexPath.row % 2 == 0 ? UIColor.white : UIColor.systemGray6
+        let backColor: UIColor = row % 2 == 0 ? .white : .systemGray6
         
         cell.selectionStyle = .none
         cell.accessoryType = .disclosureIndicator
@@ -55,6 +59,8 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         _ = names[indexPath.row]
+        let viewController = MeetingsDetailViewController()
+        present(viewController, animated: true, completion: nil)
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/publicmeetings-ios/Controllers/MoreViewController.swift
+++ b/publicmeetings-ios/Controllers/MoreViewController.swift
@@ -15,7 +15,6 @@ class MoreViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     var tableView = UITableView()
     
-    
     //MARK: - ViewController Delegates
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/publicmeetings-ios/Info.plist
+++ b/publicmeetings-ios/Info.plist
@@ -49,6 +49,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>The app would like access to maps so it can display meeting locations. </string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>The app would like access to maps so it can display meeting locations. </string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/publicmeetings-ios/Views/MeetingsDetailView.swift
+++ b/publicmeetings-ios/Views/MeetingsDetailView.swift
@@ -1,0 +1,96 @@
+//
+//  MeetingsDetailView.swift
+//  publicmeetings-ios
+//
+//  Created by mpc on 10/6/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+import MapKit
+
+class MeetingsDetailView: UIView, CLLocationManagerDelegate, MKMapViewDelegate {
+
+    //MARK: - Properties
+    var mapView: MKMapView = {
+        let map = MKMapView()
+        map.translatesAutoresizingMaskIntoConstraints = false
+        return map
+    }()
+    
+    var locationManager = CLLocationManager()
+    
+    //MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        backgroundColor = .clear
+        mainSetup()
+   }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    fileprivate func initializeMapView() {
+        mapView.delegate = self
+        mapView.showsUserLocation = true
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.requestWhenInUseAuthorization()
+        locationManager.delegate = self
+        
+        let noLocation = CLLocationCoordinate2D()
+        let viewRegion = MKCoordinateRegion(center: noLocation, latitudinalMeters: Distance.standard, longitudinalMeters: Distance.standard)
+        mapView.setRegion(viewRegion, animated: false)
+        mapView.showsUserLocation = true
+        
+        // Check for Location Services
+        if (CLLocationManager.locationServicesEnabled()) {
+            locationManager.requestAlwaysAuthorization()
+            locationManager.requestWhenInUseAuthorization()
+        }
+        
+        //Zoom to user location
+        if let userLocation = locationManager.location?.coordinate {
+            let viewRegion = MKCoordinateRegion(center: userLocation, latitudinalMeters: Distance.standard, longitudinalMeters: Distance.standard)
+            mapView.setRegion(viewRegion, animated: false)
+        }
+        
+        DispatchQueue.main.async {
+            self.locationManager.startUpdatingLocation()
+        }
+    }
+    
+    //MARK: - Setup and Layout
+    override func layoutSubviews() {
+        //createRouteButton.rounded()
+        //existingRoutesButton.rounded()
+    }
+    
+    fileprivate func mainSetup() {
+        initializeMapView()
+        
+        setupView()
+        setupLayout()
+        setupActions()
+    }
+    
+    private func setupView() {
+        addSubview(mapView)
+
+    }
+    
+    private func setupLayout() {
+        NSLayoutConstraint.activate([
+            mapView.topAnchor.constraint(equalToSystemSpacingBelow: topAnchor, multiplier: 0.0),
+            mapView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            mapView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            mapView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -1 * Screen.height * 0.40),
+            mapView.heightAnchor.constraint(equalToConstant: Screen.height * 0.40)
+        ])
+    }
+    
+    private func setupActions() {
+
+    }
+}


### PR DESCRIPTION
Add a basic Meeting Detail screen with a map.  The screen
is presented when the user presses a meeting (cell) from
the MeetingsViewController.  When completed, the detail
screen will show the information and map location for the
specific meeting.

Add constants files for screen size and location information.

Performed some micro improvements on existing code.  Not
changing the functionality, but improving the way the code
is written.

Changes to be committed:
	modified:   publicmeetings-ios.xcodeproj/project.pbxproj
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Cells/MoreCell.swift
	new file:   publicmeetings-ios/Constants/Accuracy.swift
	new file:   publicmeetings-ios/Constants/Screen.swift
	new file:   publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/Controllers/MoreViewController.swift
	modified:   publicmeetings-ios/Info.plist
	new file:   publicmeetings-ios/Views/MeetingsDetailView.swift