### PR TITLE
Meetings Badge

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -8,6 +8,11 @@
 
 import UIKit
 
+protocol BadgeDelegate: class {
+    func incrementBadgeValue(item: Int)
+    func decrementBadgeValue(item: Int)
+}
+
 class MeetingCell: UITableViewCell {
 
     //MARK: - Properties
@@ -27,7 +32,12 @@ class MeetingCell: UITableViewCell {
         return button
     }()
     
+    weak var badgeDelegate: BadgeDelegate?
+    
     var meetingAdded: Bool = false
+    var badgeCount: Int = 0
+    
+    var tabBarController = TabBarController()
     
     //MARK: - Initialization
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -76,9 +86,13 @@ class MeetingCell: UITableViewCell {
         meetingAdded = !meetingAdded
         
         if meetingAdded {
-             sender.setImage(UIImage(systemName: "calendar.badge.plus"), for: .normal)
+            sender.setImage(UIImage(systemName: "calendar.badge.plus"), for: .normal)
+            badgeDelegate?.incrementBadgeValue(item: 0)
         } else {
-             sender.setImage(UIImage(systemName: "calendar"), for: .normal)
+            sender.setImage(UIImage(systemName: "calendar"), for: .normal)
+            badgeDelegate?.decrementBadgeValue(item: 0)
         }
     }
 }
+
+

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class MeetingsViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+class MeetingsViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, BadgeDelegate {
 
     //MARK: - Properties
     var meetingLocality: UISegmentedControl = {
@@ -29,7 +29,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         
         //Temporary - Proof of concept only
         tabBarController?.tabBar.items?[0].badgeColor = UIColor(named: "devictBlue")
-        tabBarController?.tabBar.items?[0].badgeValue = "3"
+        tabBarController?.tabBar.items?[0].badgeValue = "0"
 
         setupView()
         setupLayout()
@@ -50,6 +50,8 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         let row = indexPath.row
         let backColor: UIColor = row % 2 == 0 ? .white : .systemGray6
         
+
+        cell.badgeDelegate = self
         cell.selectionStyle = .none
         cell.accessoryType = .disclosureIndicator
         cell.backgroundColor = backColor
@@ -66,7 +68,21 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 45.0
     }
-        
+    
+    //MARK: - BadgeDelegate 
+    func incrementBadgeValue(item: Int) {
+        guard let currentBadgeValue = tabBarController?.tabBar.items![item].badgeValue else { return }
+        let currentValue: Int = Int(currentBadgeValue) ?? 0
+        tabBarController?.tabBar.items![item].badgeValue = String(currentValue + 1)
+    }
+    
+    func decrementBadgeValue(item: Int) {
+        guard let currentBadgeValue = tabBarController?.tabBar.items![item].badgeValue else { return }
+        let currentValue: Int = Int(currentBadgeValue) ?? 0
+        if currentValue == 0 { return }
+        tabBarController?.tabBar.items![item].badgeValue = String(currentValue - 1)
+    }
+            
     //MARK: - Setup and Layout
     private func setScreenTitle() {
         DispatchQueue.main.async {

--- a/publicmeetings-ios/TabBar/TabBarController.swift
+++ b/publicmeetings-ios/TabBar/TabBarController.swift
@@ -42,3 +42,4 @@ class TabBarController: UITabBarController {
         UITabBar.appearance().unselectedItemTintColor = .black
     }
 }
+


### PR DESCRIPTION
Add BadgeDelegate to trigger methods when a calendar reminder
button is tapped.  The button toggles whether to add the event
to your calendar and the badge will increase or decrease the
badge value accordingly.

TODO: The increment and decrement works, but logic needs to be
added to handle no reminders (hide badge) and possibly end-cases
where underflow might occur (resulting in negative values).

Additionally, the badge shouldn't appear initially, as there is
no value associated with meetings.  Currently, it serves as a
placeholder for demonstration purposes.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/TabBar/TabBarController.swift