### PR TITLE
Search screen

### DIFF
--- a/publicmeetings-ios.xcodeproj/project.pbxproj
+++ b/publicmeetings-ios.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		E51FA4A72344DFF6005C5091 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51FA4A62344DFF6005C5091 /* TabBarController.swift */; };
 		E525261923490A150003B575 /* devict-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = E525261823490A150003B575 /* devict-logo.png */; };
 		E525261B234911070003B575 /* MoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E525261A234911070003B575 /* MoreCell.swift */; };
+		E52958822353145A00E1F2D7 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52958812353145A00E1F2D7 /* SearchViewController.swift */; };
 		E52E43D6234854CA00DF9D5B /* MoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52E43D5234854CA00DF9D5B /* MoreViewController.swift */; };
 		E52E43DA23485B3600DF9D5B /* MeetingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52E43D923485B3600DF9D5B /* MeetingsViewController.swift */; };
 		E53056CB23516D870030D715 /* government3x.png in Resources */ = {isa = PBXBuildFile; fileRef = E53056C923516D870030D715 /* government3x.png */; };
@@ -63,6 +64,7 @@
 		E51FA4A62344DFF6005C5091 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		E525261823490A150003B575 /* devict-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "devict-logo.png"; sourceTree = "<group>"; };
 		E525261A234911070003B575 /* MoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreCell.swift; sourceTree = "<group>"; };
+		E52958812353145A00E1F2D7 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		E52E43D5234854CA00DF9D5B /* MoreViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreViewController.swift; sourceTree = "<group>"; };
 		E52E43D923485B3600DF9D5B /* MeetingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingsViewController.swift; sourceTree = "<group>"; };
 		E53056C923516D870030D715 /* government3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = government3x.png; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 				E511CFF0234A8FC300807CAF /* MeetingsDetailViewController.swift */,
 				E511CFF2234ACD8D00807CAF /* MinutesViewController.swift */,
 				E52E43D5234854CA00DF9D5B /* MoreViewController.swift */,
+				E52958812353145A00E1F2D7 /* SearchViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -377,6 +380,7 @@
 				E51FA4A72344DFF6005C5091 /* TabBarController.swift in Sources */,
 				E52E43D6234854CA00DF9D5B /* MoreViewController.swift in Sources */,
 				E54DA36F234431E60070241F /* SceneDelegate.swift in Sources */,
+				E52958822353145A00E1F2D7 /* SearchViewController.swift in Sources */,
 				E514FAAC2347330D00075816 /* MeetingCell.swift in Sources */,
 				E511CFF5234ACE5800807CAF /* MinutesCell.swift in Sources */,
 				E525261B234911070003B575 /* MoreCell.swift in Sources */,

--- a/publicmeetings-ios/Controllers/MinutesViewController.swift
+++ b/publicmeetings-ios/Controllers/MinutesViewController.swift
@@ -25,6 +25,10 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
         setupLayout()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        setScreenTitle()
+    }
+    
     //MARK: - TableView delegates
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         minutes.count

--- a/publicmeetings-ios/Controllers/SearchViewController.swift
+++ b/publicmeetings-ios/Controllers/SearchViewController.swift
@@ -1,0 +1,40 @@
+//
+//  SearchViewController.swift
+//  publicmeetings-ios
+//
+//  Created by mpc on 10/13/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+class SearchViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemTeal
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        setScreenTitle()
+    }
+    
+    //MARK: - Setup and Layout
+    private func setScreenTitle() {
+        DispatchQueue.main.async {
+            self.tabBarController?.navigationItem.title = "Search"
+        }
+    }
+    
+    private func setupView() {
+        
+    }
+    
+    private func setupLayout() {
+        
+    }
+    
+    private func setupActions() {
+        
+    }
+}

--- a/publicmeetings-ios/TabBar/TabBarController.swift
+++ b/publicmeetings-ios/TabBar/TabBarController.swift
@@ -16,25 +16,29 @@ class TabBarController: UITabBarController {
         //MARK: - Properties
         let meetingsViewController = MeetingsViewController()
         let minutesViewController = MinutesViewController()
+        let searchViewController = SearchViewController()
         let moreViewController = MoreViewController()
          
         //MARK: - TabBar image setup
         let config = UIImage.SymbolConfiguration(weight: .heavy)
         let meetingImage = UIImage(systemName: "calendar", withConfiguration: config)
         let minutesImage = UIImage(systemName: "clock", withConfiguration: config)
+        let searchImage = UIImage(systemName: "magnifyingglass", withConfiguration: config)
         let moreImage = UIImage(systemName: "ellipsis.circle", withConfiguration: config)
         
         meetingsViewController.tabBarItem = UITabBarItem(title: "Meetings", image: meetingImage, selectedImage: meetingImage)
         minutesViewController.tabBarItem = UITabBarItem(title: "Minutes", image: minutesImage, selectedImage: minutesImage)
+        searchViewController.tabBarItem = UITabBarItem(title: "Search", image: searchImage, selectedImage: searchImage)
         moreViewController.tabBarItem = UITabBarItem(title: "More", image: moreImage, selectedImage: moreImage)
         
         //MARK: - Navigation
         meetingsViewController.navigationController?.navigationBar.topItem?.title = "Meetings"
         minutesViewController.navigationController?.navigationBar.topItem?.title = "Minutes"
+        searchViewController.navigationController?.navigationBar.topItem?.title = "Search"
         moreViewController.navigationController?.navigationBar.topItem?.title = "More"
          
         //MARK: - ViewController configuration
-        let viewControllerList = [meetingsViewController, minutesViewController, moreViewController]
+        let viewControllerList = [meetingsViewController, minutesViewController, searchViewController, moreViewController]
         viewControllers = viewControllerList
         
         //MARK: - TabBar configuration


### PR DESCRIPTION
Add a basic search screen to the tab bar items.

Fixed an issue with the screen titles not setting properly
when choosing a screen from the tab bar.

Changes to be committed:
	modified:   publicmeetings-ios.xcodeproj/project.pbxproj
	modified:   publicmeetings-ios/Controllers/MinutesViewController.swift
	new file:   publicmeetings-ios/Controllers/SearchViewController.swift
	modified:   publicmeetings-ios/TabBar/TabBarController.swift