### PR TITLE
Card style cells

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -54,6 +54,16 @@ class MeetingCell: UITableViewCell {
         setupView()
         setupLayout()
         setupActions()
+        
+        backgroundColor = .clear
+        //layer.masksToBounds = false
+        layer.shadowOpacity = 0.23
+        layer.shadowRadius = 4
+        layer.shadowOffset = CGSize(width: 6.0, height: 6.0)
+        layer.shadowColor = UIColor.black.cgColor
+
+        contentView.backgroundColor = .white
+        //contentView.layer.cornerRadius = 12
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -77,13 +87,13 @@ class MeetingCell: UITableViewCell {
             name.widthAnchor.constraint(equalToConstant: 200.0),
             name.heightAnchor.constraint(equalToConstant: 35.0),
             
-            reminder.centerYAnchor.constraint(equalTo: centerYAnchor),
+            reminder.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5.0),
             reminder.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -40.0),
             reminder.widthAnchor.constraint(equalToConstant: 40.0),
             reminder.heightAnchor.constraint(equalToConstant: 40.0),
             
-            share.centerYAnchor.constraint(equalTo: centerYAnchor),
-            share.trailingAnchor.constraint(equalTo: reminder.leadingAnchor, constant: -30.0),
+            share.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5.0),
+            share.trailingAnchor.constraint(equalTo: reminder.leadingAnchor, constant: -10.0),
             share.widthAnchor.constraint(equalToConstant: 40.0),
             share.heightAnchor.constraint(equalToConstant: 40.0)
         ])

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -61,7 +61,12 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         cell.accessoryType = .disclosureIndicator
         cell.backgroundColor = backColor
         cell.name.text = meetings[row].title
+
         return cell
+    }
+    
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        cell.contentView.layer.masksToBounds = true
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -71,7 +76,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 45.0
+        return 100.0
     }
     
     //MARK: - Setup and Layout


### PR DESCRIPTION
Add card style cells for the meeting information.  Updated
the constraints on the share and calendar button so they
appear on the bottom corner of the cell.

Known issues:  When scrolling back up from the bottom, the
cell loses the shadow.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift