### PR TITLE
Card style cells

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -56,14 +56,15 @@ class MeetingCell: UITableViewCell {
         setupActions()
         
         backgroundColor = .clear
-        //layer.masksToBounds = false
+        layer.masksToBounds = false
         layer.shadowOpacity = 0.23
         layer.shadowRadius = 4
-        layer.shadowOffset = CGSize(width: 6.0, height: 6.0)
+        layer.cornerRadius = 12.0
+        layer.shadowOffset = CGSize(width: 0.0, height: 6.0)
         layer.shadowColor = UIColor.black.cgColor
 
         contentView.backgroundColor = .white
-        //contentView.layer.cornerRadius = 12
+        contentView.layer.cornerRadius = 12.0
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -54,12 +54,10 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell") as! MeetingCell
         let row = indexPath.row
-        let backColor: UIColor = row % 2 == 0 ? .white : .systemGray6
         
         cell.badgeDelegate = self
         cell.selectionStyle = .none
-        cell.accessoryType = .disclosureIndicator
-        cell.backgroundColor = backColor
+        cell.backgroundColor = .white
         cell.name.text = meetings[row].title
 
         return cell
@@ -92,6 +90,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
+        tableView.separatorStyle = .none
         tableView.register(MeetingCell.self, forCellReuseIdentifier: "cell")
         tableView.tableFooterView = UIView()
     }


### PR DESCRIPTION
Tweak the look and feel for the cards.  Removed the
dividing line between cells.  Add rounded corners.
Remove the accessoryType, so there is no disclosure
indicator.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift