### PR TITLE
Card style cells - Meeting minutes

### DIFF
--- a/publicmeetings-ios/Cells/MinutesCell.swift
+++ b/publicmeetings-ios/Cells/MinutesCell.swift
@@ -25,6 +25,17 @@ class MinutesCell: UITableViewCell {
             
         setupView()
         setupLayout()
+        
+        backgroundColor = .clear
+        layer.masksToBounds = false
+        layer.shadowOpacity = 0.23
+        layer.shadowRadius = 4
+        layer.cornerRadius = 12.0
+        layer.shadowOffset = CGSize(width: 0.0, height: 6.0)
+        layer.shadowColor = UIColor.black.cgColor
+
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 12.0
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/publicmeetings-ios/Controllers/MinutesViewController.swift
+++ b/publicmeetings-ios/Controllers/MinutesViewController.swift
@@ -45,6 +45,10 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
         return cell
     }
     
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        cell.contentView.layer.masksToBounds = true
+    }
+    
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 120.0
     }


### PR DESCRIPTION
Add card style cells for the meeting minutes information.
Updated the constraints on the share and calendar button so
they appear on the bottom corner of the cell.

Known issues:  When scrolling back up from the bottom, the
cell loses the shadow.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MinutesCell.swift
	modified:   publicmeetings-ios/Controllers/MinutesViewController.swift