### PR TITLE
Display Testing

### DIFF
--- a/publicmeetings-ios/Cells/MinutesCell.swift
+++ b/publicmeetings-ios/Cells/MinutesCell.swift
@@ -31,11 +31,12 @@ class MinutesCell: UITableViewCell {
         layer.shadowOpacity = 0.23
         layer.shadowRadius = 4
         layer.cornerRadius = 12.0
-        layer.shadowOffset = CGSize(width: 0.0, height: 6.0)
+        layer.shadowOffset = CGSize(width: 6.0, height: 6.0)
         layer.shadowColor = UIColor.black.cgColor
 
         contentView.backgroundColor = .white
         contentView.layer.cornerRadius = 12.0
+        contentView.clipsToBounds = false
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -87,6 +87,8 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     private func setupView() {
         [meetingLocality, tableView].forEach { view.addSubview($0) }
         
+        view.backgroundColor = .systemGray6
+        
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
@@ -102,7 +104,8 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
             meetingLocality.heightAnchor.constraint(equalToConstant: 30.0),
             
             tableView.topAnchor.constraint(equalToSystemSpacingBelow: meetingLocality.bottomAnchor, multiplier: 0.0),
-            tableView.widthAnchor.constraint(equalToConstant: Screen.width),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15.0),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }

--- a/publicmeetings-ios/Controllers/MinutesViewController.swift
+++ b/publicmeetings-ios/Controllers/MinutesViewController.swift
@@ -19,8 +19,6 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .white
-        
         setupView()
         setupLayout()
     }
@@ -39,7 +37,7 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
         let row = indexPath.row
         
         cell.selectionStyle = .none
-        cell.backgroundColor = .white
+        cell.backgroundColor = .clear
         cell.minutes.text = minutes[row]
     
         return cell
@@ -63,19 +61,21 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
      
      private func setupView() {
          view.addSubview(tableView)
+         view.backgroundColor = .systemGray6
 
          tableView.translatesAutoresizingMaskIntoConstraints = false
          tableView.delegate = self
          tableView.dataSource = self
          tableView.register(MinutesCell.self, forCellReuseIdentifier: "minutesCell")
          tableView.tableFooterView = UIView()
+         tableView.clipsToBounds = false
      }
      
      private func setupLayout() {
          NSLayoutConstraint.activate([
              tableView.topAnchor.constraint(equalToSystemSpacingBelow: view.topAnchor, multiplier: 5.0),
-             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10.0),
-             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10.0),
+             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
+             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15.0),
              tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
          ])
      }


### PR DESCRIPTION
Test a different display design, where the cards are not
flush against the leading and trailing edges.  Affects
both the meeting screen and the minutes screen.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MinutesCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/Controllers/MinutesViewController.swift