### PR TITLE
Layout and display

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -23,7 +23,6 @@ class MeetingCell: UITableViewCell {
         v.backgroundColor = .white
         v.layer.borderColor = UIColor.black.cgColor
         v.layer.borderWidth = 0.3
-        v.layer.cornerRadius = Standard.cornerRadius
         v.clipsToBounds = true
         return v
     }()
@@ -51,7 +50,7 @@ class MeetingCell: UITableViewCell {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = .black
         label.textAlignment = .left
-        label.font = UIFont(name: "AvenirNext-Regular", size: 10.0)
+        label.font = UIFont(name: "Damascus", size: 10.0)
         label.textAlignment = .right
         return label
     }()
@@ -100,6 +99,7 @@ class MeetingCell: UITableViewCell {
     //MARK: - Setup and Layout
     private func setupView() {
         [view, name, desc, meetingDate, reminder, share].forEach { contentView.addSubview($0) }
+        backgroundColor = .clear
     }
     
     private func setupLayout() {
@@ -117,6 +117,7 @@ class MeetingCell: UITableViewCell {
             meetingDate.centerYAnchor.constraint(equalTo: name.centerYAnchor),
             meetingDate.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -25.0),
             meetingDate.widthAnchor.constraint(equalToConstant: 70.0),
+            meetingDate.heightAnchor.constraint(equalToConstant: 20.0),
             
             desc.topAnchor.constraint(equalTo: name.bottomAnchor, constant: 2.0),
             desc.leadingAnchor.constraint(equalTo: name.leadingAnchor),

--- a/publicmeetings-ios/Cells/MoreCell.swift
+++ b/publicmeetings-ios/Cells/MoreCell.swift
@@ -44,7 +44,8 @@ class MoreCell: UITableViewCell {
             
             version.centerYAnchor.constraint(equalTo: centerYAnchor),
             version.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -40.0),
-            version.widthAnchor.constraint(equalToConstant: 40.0)
+            version.widthAnchor.constraint(equalToConstant: 40.0),
+            version.heightAnchor.constraint(equalToConstant: 35.0)
         ])
     }
     

--- a/publicmeetings-ios/Colors.xcassets/devictBlue.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/devictBlue.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x20",
+          "red" : "0x42",
           "alpha" : "1.000",
-          "blue" : "0xDF",
-          "green" : "0x6D"
+          "blue" : "0xBD",
+          "green" : "0xA8"
         }
       }
     }

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -14,7 +14,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     var meetingLocality: UISegmentedControl = {
         let segmented = UISegmentedControl(items: ["All", "Wichita", "County", "State"])
         segmented.translatesAutoresizingMaskIntoConstraints = false
-        segmented.backgroundColor = UIColor(named: "softBlue")
+        segmented.backgroundColor = UIColor(named: "devictBlue")
         segmented.selectedSegmentIndex = 0
         return segmented
     }()
@@ -57,7 +57,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         
         cell.badgeDelegate = self
         cell.selectionStyle = .none
-        cell.backgroundColor = .white
+        cell.backgroundColor = .clear
         cell.name.text = meetings[row].title
         cell.desc.text = meetings[row].description
         cell.meetingDate.text = meetings[row].date?.description
@@ -89,14 +89,15 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     private func setupView() {
         [meetingLocality, tableView].forEach { view.addSubview($0) }
         
-        view.backgroundColor = .white
+        view.backgroundColor = UIColor(named: "devictTan")
         
-        tableView.backgroundColor = .clear
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
         tableView.separatorStyle = .none
         tableView.register(MeetingCell.self, forCellReuseIdentifier: "cell")
+        tableView.backgroundColor = .clear
+        
         tableView.tableFooterView = UIView()
     }
     
@@ -146,7 +147,7 @@ extension MeetingsViewController: BadgeDelegate {
     
     func incrementBadgeValue(item: Int) {
         var currentValue: Int = 0
-        
+    
         if tabBarController?.tabBar.items![item].badgeValue == "" {
             currentValue = 0
         } else {

--- a/publicmeetings-ios/SceneDelegate.swift
+++ b/publicmeetings-ios/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let rootViewController = TabBarController()
         navigationController = UINavigationController()
         navigationController?.viewControllers = [rootViewController]
-        navigationController?.navigationBar.barTintColor = UIColor(named: "papayaWhip")
+        navigationController?.navigationBar.barTintColor = UIColor(named: "devictOrange")
         UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.foregroundColor : UIColor.black]
         
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)


### PR DESCRIPTION
Update the navigation bar color to DevICT's color.
Went back to squared borders for the meetings cells.
Changed the meeting view controller color to DevICT tan.
Change the value for DevICT blue to something lighter.
Code cleanup

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Cells/MoreCell.swift
	modified:   publicmeetings-ios/Colors.xcassets/devictBlue.colorset/Contents.json
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/SceneDelegate.swift