### PR TITLE
Meeting data + Meeting screen

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -50,8 +50,34 @@ class MeetingCell: UITableViewCell {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = .black
         label.textAlignment = .left
-        label.font = UIFont(name: "Damascus", size: 10.0)
-        label.textAlignment = .right
+        label.font = UIFont(name: "Damascus", size: 13.0)
+        return label
+    }()
+    
+    var address: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .left
+        label.font = Standard.font
+        return label
+    }()
+    
+    var location: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .left
+        label.font = Standard.font
+        return label
+    }()
+    
+    var city: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .left
+        label.font = Standard.font
         return label
     }()
     
@@ -98,7 +124,7 @@ class MeetingCell: UITableViewCell {
     
     //MARK: - Setup and Layout
     private func setupView() {
-        [view, name, desc, meetingDate, reminder, share].forEach { contentView.addSubview($0) }
+        [view, name, desc, meetingDate, address, location, city, reminder, share].forEach { contentView.addSubview($0) }
         backgroundColor = .clear
     }
     
@@ -109,10 +135,10 @@ class MeetingCell: UITableViewCell {
             view.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3.0),
             view.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -3.0),
             
-            name.topAnchor.constraint(equalTo: view.topAnchor, constant: 3.0),
+            name.topAnchor.constraint(equalTo: view.topAnchor, constant: 6.0),
             name.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
             name.widthAnchor.constraint(equalToConstant: 200.0),
-            name.heightAnchor.constraint(equalToConstant: 35.0),
+            name.heightAnchor.constraint(equalToConstant: 20.0),
             
             meetingDate.centerYAnchor.constraint(equalTo: name.centerYAnchor),
             meetingDate.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -25.0),
@@ -121,16 +147,26 @@ class MeetingCell: UITableViewCell {
             
             desc.topAnchor.constraint(equalTo: name.bottomAnchor, constant: 2.0),
             desc.leadingAnchor.constraint(equalTo: name.leadingAnchor),
-            desc.widthAnchor.constraint(equalToConstant: 300.0),
-            desc.heightAnchor.constraint(equalToConstant: 35.0),
+            desc.widthAnchor.constraint(equalToConstant: 200.0),
+            desc.heightAnchor.constraint(equalToConstant: 20.0),
+            
+            address.topAnchor.constraint(equalTo: desc.bottomAnchor, constant: 2.0),
+            address.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
+            address.widthAnchor.constraint(equalToConstant: 200.0),
+            address.heightAnchor.constraint(equalToConstant: 20.0),
+            
+            city.topAnchor.constraint(equalTo: address.bottomAnchor, constant: 2.0),
+            city.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
+            city.widthAnchor.constraint(equalToConstant: 200.0),
+            city.heightAnchor.constraint(equalToConstant: 20.0),
             
             reminder.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5.0),
-            reminder.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -40.0),
+            reminder.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5.0),
             reminder.widthAnchor.constraint(equalToConstant: 40.0),
             reminder.heightAnchor.constraint(equalToConstant: 40.0),
             
             share.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5.0),
-            share.trailingAnchor.constraint(equalTo: reminder.leadingAnchor, constant: -10.0),
+            share.trailingAnchor.constraint(equalTo: reminder.leadingAnchor, constant: -5.0),
             share.widthAnchor.constraint(equalToConstant: 40.0),
             share.heightAnchor.constraint(equalToConstant: 40.0)
         ])

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -60,7 +60,9 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         cell.backgroundColor = .clear
         cell.name.text = meetings[row].title
         cell.desc.text = meetings[row].description
-        cell.meetingDate.text = meetings[row].date?.description
+        cell.address.text = meetings[row].address
+        cell.city.text = meetings[row].city
+        cell.meetingDate.text = meetings[row].date
 
         return cell
     }

--- a/publicmeetings-ios/Models/Meeting.swift
+++ b/publicmeetings-ios/Models/Meeting.swift
@@ -14,17 +14,23 @@ enum MeetingType {
 }
 
 struct Meeting {
-
     var title: String
     var description: String
-    var date: Date?
+    var date: String
+    var address: String
     var location: String
+    var city: String
     
-    init(title: String = "", description: String = "", location: String) {
+    
+    //FIXME: - Making date a string for until we have a data feed.
+    //FIXME: - Also, address information will neeed to come from feed.
+    init(title: String = "", description: String = "", date: String) {
         self.title = title
         self.description = description
-        self.location = location
-        self.date = generateFutureDate()
+        self.date = date
+        self.address = "455​ N Main"
+        self.location = "1st Floor"
+        self.city = "Wichita"
     }
 
     func generateFutureDate() -> Date {

--- a/publicmeetings-ios/Utils/CreateMeetingData.swift
+++ b/publicmeetings-ios/Utils/CreateMeetingData.swift
@@ -12,49 +12,62 @@ func meetingData() -> [Meeting] {
     var meetings = [Meeting]()
     var meeting: Meeting
     
-    meeting = Meeting(title: "City Council", description: "City council's meeting", location: "Wichita")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "Town Hall", description: "Wichita Town Hall", location: "Wichita")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "City Planning", description: "Discuss planning and zoning laws", location: "Wichita")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "State Wellness Planning", description: "Discuss health and human services", location: "State")
-    meetings.append(meeting)
-   
-    meeting = Meeting(title: "County ", description: "City council's meeting", location: "County")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "Special elections", description: "Election runoff discussion", location: "County")
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "08/06/2019")
     meetings.append(meeting)
     
-    meeting = Meeting(title: "State planning board", description: "Meeting of the state planners", location: "State")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "County planning board", description: "Meeting of the state planners", location: "County")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "Wichita planning board", description: "Meeting of the state planners", location: "Wichita")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "Town Hall", description: "Wichita Town Hall", location: "Wichita")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "State planning board", description: "Meeting of the state planners", location: "State")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "Wichita Board", description: "Meeting of the Board", location: "Wichita")
-    meetings.append(meeting)
-   
-    meeting = Meeting(title: "General elections", description: "General election meeting", location: "State")
-    meetings.append(meeting)
-
-    meeting = Meeting(title: "Primary elections", description: "Primary election meeting", location: "State")
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "08/13/2019")
     meetings.append(meeting)
     
-    meeting = Meeting(title: "School Board", description: "Discuss local education policy", location: "Wichita")
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "08/20/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Consent workshop", date: "08/27/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "09/03/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "09/10/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "09/17/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Consent workshop", date: "09/22/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "10/01/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "10/08/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "10/15/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Consent workshop", date: "10/22/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "11/05/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "11/12/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "11/19/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Consent workshop", date: "11/26/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "12/03/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "12/10/2019")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "12/17/2019")
     meetings.append(meeting)
 
     return meetings


### PR DESCRIPTION
Update the data model to match the data from Wichita's actual
calendar of events.

The model is currently defining everything as String for the
sake of simplicity.  The model will need to be updated using
correct data types.

Update the Meeting screen to display additional data.

With this change, we're using location to indicate where
the meeting is held.  We will need to add an additional
field to indicate whether the meeting is city, county, state,
so that the segmented control will function properly.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/Models/Meeting.swift
	modified:   publicmeetings-ios/Utils/CreateMeetingData.swift