### PR TITLE
No Meetings

### DIFF
--- a/publicmeetings-ios.xcodeproj/project.pbxproj
+++ b/publicmeetings-ios.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		E56077AB235C9AEB003D8F26 /* StandardValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56077AA235C9AEB003D8F26 /* StandardValues.swift */; };
 		E56A792F2361E126001376EC /* AgendasViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56A792E2361E126001376EC /* AgendasViewController.swift */; };
 		E56A79312361E137001376EC /* AgendasCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56A79302361E137001376EC /* AgendasCell.swift */; };
+		E5F0305C23631EC400F65234 /* NoMeetingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F0305B23631EC400F65234 /* NoMeetingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,7 @@
 		E56077AA235C9AEB003D8F26 /* StandardValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardValues.swift; sourceTree = "<group>"; };
 		E56A792E2361E126001376EC /* AgendasViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgendasViewController.swift; sourceTree = "<group>"; };
 		E56A79302361E137001376EC /* AgendasCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgendasCell.swift; sourceTree = "<group>"; };
+		E5F0305B23631EC400F65234 /* NoMeetingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoMeetingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +129,7 @@
 			children = (
 				E511CFE9234A8D4800807CAF /* MeetingsDetailView.swift */,
 				E52268522353945F0036163B /* SearchView.swift */,
+				E5F0305B23631EC400F65234 /* NoMeetingsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -420,6 +423,7 @@
 				E52E43D6234854CA00DF9D5B /* MoreViewController.swift in Sources */,
 				E54DA36F234431E60070241F /* SceneDelegate.swift in Sources */,
 				E52958822353145A00E1F2D7 /* SearchViewController.swift in Sources */,
+				E5F0305C23631EC400F65234 /* NoMeetingsView.swift in Sources */,
 				E514FAAC2347330D00075816 /* MeetingCell.swift in Sources */,
 				E511CFF5234ACE5800807CAF /* MinutesCell.swift in Sources */,
 				E525261B234911070003B575 /* MoreCell.swift in Sources */,

--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -49,7 +49,7 @@ class MeetingCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = .black
-        label.textAlignment = .left
+        label.textAlignment = .right
         label.font = UIFont(name: "Damascus", size: 13.0)
         return label
     }()
@@ -135,13 +135,13 @@ class MeetingCell: UITableViewCell {
             view.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3.0),
             view.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -3.0),
             
-            name.topAnchor.constraint(equalTo: view.topAnchor, constant: 6.0),
+            name.topAnchor.constraint(equalTo: view.topAnchor, constant: 8.0),
             name.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
             name.widthAnchor.constraint(equalToConstant: 200.0),
             name.heightAnchor.constraint(equalToConstant: 20.0),
             
             meetingDate.centerYAnchor.constraint(equalTo: name.centerYAnchor),
-            meetingDate.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -25.0),
+            meetingDate.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -13.0),
             meetingDate.widthAnchor.constraint(equalToConstant: 70.0),
             meetingDate.heightAnchor.constraint(equalToConstant: 20.0),
             

--- a/publicmeetings-ios/Constants/StandardValues.swift
+++ b/publicmeetings-ios/Constants/StandardValues.swift
@@ -12,4 +12,5 @@ import UIKit
 struct Standard {
     static let cornerRadius: CGFloat = 8.0
     static let font: UIFont = UIFont(name: "Damascus", size: 16.0)!
+    static let largeFont: UIFont = UIFont(name: "Damascus", size: 40.0)!
 }

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -11,13 +11,20 @@ import UIKit
 class MeetingsViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
     //MARK: - Properties
-    var meetingLocality: UISegmentedControl = {
+    var venue: UISegmentedControl = {
         let segmented = UISegmentedControl(items: ["All", "Wichita", "County", "State"])
         segmented.translatesAutoresizingMaskIntoConstraints = false
         segmented.backgroundColor = UIColor(named: "devictBlue")
         segmented.selectedSegmentIndex = 0
         return segmented
     }()
+    
+    var noMeetingView: UIView = {
+        let view = NoMeetingsView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     
     var tableView = UITableView()
     
@@ -89,7 +96,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
     private func setupView() {
-        [meetingLocality, tableView].forEach { view.addSubview($0) }
+        [venue, noMeetingView, tableView].forEach { view.addSubview($0) }
         
         view.backgroundColor = UIColor(named: "devictTan")
         
@@ -99,18 +106,17 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         tableView.separatorStyle = .none
         tableView.register(MeetingCell.self, forCellReuseIdentifier: "cell")
         tableView.backgroundColor = .clear
-        
         tableView.tableFooterView = UIView()
     }
     
     private func setupLayout() {
         NSLayoutConstraint.activate([
-            meetingLocality.topAnchor.constraint(equalToSystemSpacingBelow: view.topAnchor, multiplier: 11.0),
-            meetingLocality.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            meetingLocality.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            meetingLocality.heightAnchor.constraint(equalToConstant: 30.0),
+            venue.topAnchor.constraint(equalToSystemSpacingBelow: view.topAnchor, multiplier: 11.0),
+            venue.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            venue.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            venue.heightAnchor.constraint(equalToConstant: 30.0),
             
-            tableView.topAnchor.constraint(equalToSystemSpacingBelow: meetingLocality.bottomAnchor, multiplier: 1.0),
+            tableView.topAnchor.constraint(equalToSystemSpacingBelow: venue.bottomAnchor, multiplier: 1.0),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15.0),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
@@ -118,23 +124,37 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
     private func setupActions() {
-        meetingLocality.addTarget(self, action: #selector(segmentedValueChanged(sender:)), for: .valueChanged)
+        venue.addTarget(self, action: #selector(segmentedValueChanged(sender:)), for: .valueChanged)
     }
     
     //MARK: - Actions
     @objc func segmentedValueChanged(sender: UISegmentedControl) {
-        guard let location = sender.titleForSegment(at: sender.selectedSegmentIndex) else { return }
+        guard let venue = sender.titleForSegment(at: sender.selectedSegmentIndex) else { return }
           
         meetings = []
         
-        if location == "All" {
+        if venue == "All" {
             meetings = allMeetings
         } else {
             for meeting in allMeetings {
-                if meeting.location == location {
+                if meeting.venue == venue {
                     meetings.append(meeting)
                 }
             }
+
+            if meetings.count == 0 {
+                NSLayoutConstraint.activate([
+                    noMeetingView.topAnchor.constraint(equalTo: self.venue.bottomAnchor, constant: 1.0),
+                    noMeetingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                    noMeetingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                    noMeetingView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+                ])
+                
+                noMeetingView.isHidden = false
+            } else {
+                noMeetingView.isHidden = true
+            }
+            
         }
 
         tableView.reloadData()
@@ -143,7 +163,6 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
 
 extension MeetingsViewController: BadgeDelegate {
     /** Increment the badgeValue for the tabBar items
-     
     - Parameter item: The index of the tabBar of the item with the badge.
     */
     
@@ -163,7 +182,6 @@ extension MeetingsViewController: BadgeDelegate {
     }
     
     /** Decrement the badgeValue for the tabBar items.   If the badgeValue  gets to zero, the badge will be set to nil and not displayed
-     
     - Parameter item: The index of the tabBar of the item with the badge.
     */
     

--- a/publicmeetings-ios/Models/Meeting.swift
+++ b/publicmeetings-ios/Models/Meeting.swift
@@ -20,6 +20,7 @@ struct Meeting {
     var address: String
     var location: String
     var city: String
+    var venue: String
     
     
     //FIXME: - Making date a string for until we have a data feed.
@@ -31,6 +32,7 @@ struct Meeting {
         self.address = "455​ N Main"
         self.location = "1st Floor"
         self.city = "Wichita"
+        self.venue = "Wichita"
     }
 
     func generateFutureDate() -> Date {

--- a/publicmeetings-ios/Utils/CreateMeetingData.swift
+++ b/publicmeetings-ios/Utils/CreateMeetingData.swift
@@ -69,6 +69,18 @@ func meetingData() -> [Meeting] {
     
     meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "12/17/2019")
     meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "01/07/2020")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "01/14/2020")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Regular meeting", date: "01/21/2020")
+    meetings.append(meeting)
+    
+    meeting = Meeting(title: "City Council Meeting", description: "Consent workshop", date: "01/28/2020")
+    meetings.append(meeting)
 
     return meetings
 }

--- a/publicmeetings-ios/Views/NoMeetingsView.swift
+++ b/publicmeetings-ios/Views/NoMeetingsView.swift
@@ -1,0 +1,52 @@
+//
+//  NoMeetingsView.swift
+//  publicmeetings-ios
+//
+//  Created by mpc on 10/25/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+class NoMeetingsView: UIView {
+
+    var noMeetings: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.backgroundColor = .clear
+        label.textAlignment = .center
+        label.font = Standard.largeFont
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        label.text = "No scheduled meetings"
+        return label
+    }()
+        
+    //MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupView()
+        setupLayout()
+    }
+     
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    
+    //MARK: - Setup and Layout
+    private func setupView() {
+        addSubview(noMeetings)
+    }
+    
+    private func setupLayout() {
+        NSLayoutConstraint.activate([
+            noMeetings.centerXAnchor.constraint(equalTo: centerXAnchor),
+            noMeetings.centerYAnchor.constraint(equalTo: centerYAnchor),
+            noMeetings.widthAnchor.constraint(equalToConstant: Screen.width),
+            noMeetings.heightAnchor.constraint(equalToConstant: 100.0)
+        ])
+    }
+}


### PR DESCRIPTION
On the Meetings screen, if the user presses the segmented
control (for Wichita, County, State) and there's no records
of a meeting for that venue, I've added a view that indicates
there are no scheduled meetings.

This is likely only going to be the case when there's no data
feed for that venue or if there is a network issue.

Changes to be committed:
	modified:   publicmeetings-ios.xcodeproj/project.pbxproj
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Constants/StandardValues.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/Models/Meeting.swift
	modified:   publicmeetings-ios/Utils/CreateMeetingData.swift
	new file:   publicmeetings-ios/Views/NoMeetingsView.swift