### PR TITLE
Meeting card fix

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -33,6 +33,7 @@ class MeetingCell: UITableViewCell {
         label.textColor = .black
         label.textAlignment = .left
         label.font = Standard.font
+        label.baselineAdjustment = .alignCenters
         return label
     }()
     
@@ -155,7 +156,12 @@ class MeetingCell: UITableViewCell {
             address.widthAnchor.constraint(equalToConstant: 200.0),
             address.heightAnchor.constraint(equalToConstant: 20.0),
             
-            city.topAnchor.constraint(equalTo: address.bottomAnchor, constant: 2.0),
+            location.topAnchor.constraint(equalTo: address.bottomAnchor, constant: 2.0),
+            location.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
+            location.widthAnchor.constraint(equalToConstant: 200.0),
+            location.heightAnchor.constraint(equalToConstant: 20.0),
+            
+            city.topAnchor.constraint(equalTo: location.bottomAnchor, constant: 2.0),
             city.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
             city.widthAnchor.constraint(equalToConstant: 200.0),
             city.heightAnchor.constraint(equalToConstant: 20.0),

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -68,6 +68,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         cell.name.text = meetings[row].title
         cell.desc.text = meetings[row].description
         cell.address.text = meetings[row].address
+        cell.location.text = meetings[row].location
         cell.city.text = meetings[row].city
         cell.meetingDate.text = meetings[row].date
 


### PR DESCRIPTION
Left out the location information on the meeting card.  Added
it back in.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift