### PR TITLE
Meetings - Bold meeting name

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -32,7 +32,7 @@ class MeetingCell: UITableViewCell {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = .black
         label.textAlignment = .left
-        label.font = Standard.font
+        label.font = Standard.fontBold
         label.baselineAdjustment = .alignCenters
         return label
     }()
@@ -136,10 +136,10 @@ class MeetingCell: UITableViewCell {
             view.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3.0),
             view.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -3.0),
             
-            name.topAnchor.constraint(equalTo: view.topAnchor, constant: 8.0),
+            name.topAnchor.constraint(equalTo: view.topAnchor, constant: 10.0),
             name.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
             name.widthAnchor.constraint(equalToConstant: 200.0),
-            name.heightAnchor.constraint(equalToConstant: 20.0),
+            name.heightAnchor.constraint(equalToConstant: 22.0),
             
             meetingDate.centerYAnchor.constraint(equalTo: name.centerYAnchor),
             meetingDate.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -13.0),

--- a/publicmeetings-ios/Constants/StandardValues.swift
+++ b/publicmeetings-ios/Constants/StandardValues.swift
@@ -12,5 +12,6 @@ import UIKit
 struct Standard {
     static let cornerRadius: CGFloat = 8.0
     static let font: UIFont = UIFont(name: "Damascus", size: 16.0)!
+    static let fontBold: UIFont = UIFont(name: "DamascusBold", size: 16.0)!
     static let largeFont: UIFont = UIFont(name: "Damascus", size: 40.0)!
 }

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -86,7 +86,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 130.0
+        return 140.0
     }
     
     //MARK: - Setup and Layout


### PR DESCRIPTION
On the meetings screen, make the meeting name be in bold.
Adjust the label size to accomodate the font change.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Constants/StandardValues.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift