### PR TITLE
No Meeting fix

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -146,7 +146,7 @@ class MeetingCell: UITableViewCell {
             meetingDate.widthAnchor.constraint(equalToConstant: 70.0),
             meetingDate.heightAnchor.constraint(equalToConstant: 20.0),
             
-            desc.topAnchor.constraint(equalTo: name.bottomAnchor, constant: 2.0),
+            desc.topAnchor.constraint(equalTo: name.bottomAnchor, constant: 6.0),
             desc.leadingAnchor.constraint(equalTo: name.leadingAnchor),
             desc.widthAnchor.constraint(equalToConstant: 200.0),
             desc.heightAnchor.constraint(equalToConstant: 20.0),

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -22,6 +22,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     var noMeetingView: UIView = {
         let view = NoMeetingsView()
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
         return view
     }()
     
@@ -86,7 +87,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 140.0
+        return 150.0
     }
     
     //MARK: - Setup and Layout


### PR DESCRIPTION
Underneath the meetings cells, the "No Meetings Scheduled" view
is initially visible.  I hid this view as a default so it doesn't
show up.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift