### PR TITLE
No meeting fix

### DIFF
--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -131,6 +131,8 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     
     //MARK: - Actions
     @objc func segmentedValueChanged(sender: UISegmentedControl) {
+        noMeetingView.isHidden = true
+        
         guard let venue = sender.titleForSegment(at: sender.selectedSegmentIndex) else { return }
           
         meetings = []


### PR DESCRIPTION
The issue with the background view would still display due
to a state change issue.  Fixed by hiding the view prior to
a state change and let the code work it out later.

Changes to be committed:
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift