### PR TITLE
Map the meeting location

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -16,7 +16,6 @@ protocol BadgeDelegate: class {
 class MeetingCell: UITableViewCell {
 
     //MARK: - Properties
-    
     var view: UIView = {
         let v = UIView()
         v.translatesAutoresizingMaskIntoConstraints = false
@@ -61,6 +60,7 @@ class MeetingCell: UITableViewCell {
         label.textColor = .black
         label.textAlignment = .left
         label.font = Standard.font
+        label.text = ""
         return label
     }()
     
@@ -79,6 +79,17 @@ class MeetingCell: UITableViewCell {
         label.textColor = .black
         label.textAlignment = .left
         label.font = Standard.font
+        label.text = ""
+        return label
+    }()
+    
+    var state: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .left
+        label.font = Standard.font
+        label.text = ""
         return label
     }()
     
@@ -116,6 +127,7 @@ class MeetingCell: UITableViewCell {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        setupView()
     }
     
     //MARK: - Cell delegates

--- a/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import MapKit
 
 class MeetingsDetailViewController: UIViewController {
 
@@ -16,6 +17,8 @@ class MeetingsDetailViewController: UIViewController {
         return map
     }()
     
+    var meetingAddress: String = ""
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -23,7 +26,53 @@ class MeetingsDetailViewController: UIViewController {
         
         setupView()
         setupLayout()
+        
+        coordinates(forAddress: meetingAddress) {
+            (location) in
+            guard let location = location else {
+                // Handle error here.
+                return
+            }
+            
+            self.openMapForPlace(lat: location.latitude, long: location.longitude)
+        }
+        
+        
     }
+    
+    //Experimental mapping by address
+    func coordinates(forAddress address: String, completion: @escaping (CLLocationCoordinate2D?) -> Void) {
+        let geocoder = CLGeocoder()
+        geocoder.geocodeAddressString(address) {
+            (placemarks, error) in
+            guard error == nil else {
+                print("Geocoding error: \(error!)")
+                completion(nil)
+                return
+            }
+            completion(placemarks?.first?.location?.coordinate)
+        }
+    }
+    
+    public func openMapForPlace(lat:Double = 0, long:Double = 0, placeName:String = "") {
+        let latitude: CLLocationDegrees = lat
+        let longitude: CLLocationDegrees = long
+
+        let regionDistance:CLLocationDistance = 100
+        let coordinates = CLLocationCoordinate2DMake(latitude, longitude)
+        let regionSpan = MKCoordinateRegion(center: coordinates, latitudinalMeters: regionDistance, longitudinalMeters: regionDistance)
+        let options = [
+            MKLaunchOptionsMapCenterKey: NSValue(mkCoordinate: regionSpan.center),
+            MKLaunchOptionsMapSpanKey: NSValue(mkCoordinateSpan: regionSpan.span)
+        ]
+        let placemark = MKPlacemark(coordinate: coordinates, addressDictionary: nil)
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = placeName
+        mapItem.openInMaps(launchOptions: options)
+    }
+    
+    
+    
     
     //MARK: - Setup and Layout
     private func setupView() {

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -70,7 +70,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         cell.desc.text = meetings[row].description
         cell.address.text = meetings[row].address
         cell.location.text = meetings[row].location
-        cell.city.text = meetings[row].city
+        cell.city.text = meetings[row].cityState
         cell.meetingDate.text = meetings[row].date
 
         return cell
@@ -83,6 +83,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         _ = meetings[indexPath.row]
         let viewController = MeetingsDetailViewController()
+        viewController.meetingAddress = meetings[indexPath.row].mappableAddress
         present(viewController, animated: true, completion: nil)
     }
     
@@ -158,7 +159,6 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
             } else {
                 noMeetingView.isHidden = true
             }
-            
         }
 
         tableView.reloadData()

--- a/publicmeetings-ios/Models/Meeting.swift
+++ b/publicmeetings-ios/Models/Meeting.swift
@@ -20,7 +20,12 @@ struct Meeting {
     var address: String
     var location: String
     var city: String
+    var state: String
+    var zip: String
     var venue: String
+    
+    var cityState: String = ""
+    var mappableAddress: String = ""
     
     
     //FIXME: - Making date a string for until we have a data feed.
@@ -32,7 +37,12 @@ struct Meeting {
         self.address = "455​ N Main"
         self.location = "1st Floor"
         self.city = "Wichita"
+        self.state = "KS"
+        self.zip = "67202​"
         self.venue = "Wichita"
+        
+        cityState = city + " " + state
+        mappableAddress = address + "," + city + "," + state + "," + zip
     }
 
     func generateFutureDate() -> Date {


### PR DESCRIPTION
When tapping on a meeting from the meeting screen, seque to a map page that puts a pin on the meeting location.

Known issues: The mapping works, but I have an original screen that is being bypassed because I'm using Apple's MapKit and it's going straight to that screen.  The seque back goes to the screen
I developed.  The mapping code I'm using is just for proof of concept, so more work has to be done to determine how the screen is presented.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/Models/Meeting.swift