### PR TITLE
Name map location

### DIFF
--- a/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
@@ -67,7 +67,7 @@ class MeetingsDetailViewController: UIViewController {
         ]
         let placemark = MKPlacemark(coordinate: coordinates, addressDictionary: nil)
         let mapItem = MKMapItem(placemark: placemark)
-        mapItem.name = placeName
+        mapItem.name = "City Hall"
         mapItem.openInMaps(launchOptions: options)
     }
     


### PR DESCRIPTION
The label for the pinned location was unknown.  Named it "City Hall".

Changes to be committed:
	modified:   publicmeetings-ios/Controllers/MeetingsDetailViewController.swift