### PR TITLE
Minutes screen

### DIFF
--- a/publicmeetings-ios/Cells/MinutesCell.swift
+++ b/publicmeetings-ios/Cells/MinutesCell.swift
@@ -20,12 +20,31 @@ class MinutesCell: UITableViewCell {
         return v
     }()
     
-    var minutes: UILabel = {
+    var name: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .left
+        label.font = Standard.fontBold
+        label.baselineAdjustment = .alignCenters
+        return label
+    }()
+    
+    var desc: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = .black
         label.textAlignment = .left
         label.font = Standard.font
+        return label
+    }()
+    
+    var meetingDate: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .right
+        label.font = UIFont(name: "Damascus", size: 13.0)
         return label
     }()
     
@@ -48,7 +67,7 @@ class MinutesCell: UITableViewCell {
     
     //MARK: - Setup and Layout
     private func setupView() {
-        [view, minutes].forEach { contentView.addSubview($0) }
+        [view, name, desc, meetingDate].forEach { contentView.addSubview($0) }
     }
     
     private func setupLayout() {
@@ -58,10 +77,20 @@ class MinutesCell: UITableViewCell {
             view.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3.0),
             view.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -3.0),
             
-            minutes.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            minutes.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
-            minutes.widthAnchor.constraint(equalToConstant: 200.0),
-            minutes.heightAnchor.constraint(equalToConstant: 35.0)
+            name.topAnchor.constraint(equalTo: view.topAnchor, constant: 10.0),
+            name.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
+            name.widthAnchor.constraint(equalToConstant: 200.0),
+            name.heightAnchor.constraint(equalToConstant: 22.0),
+            
+            meetingDate.centerYAnchor.constraint(equalTo: name.centerYAnchor),
+            meetingDate.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -13.0),
+            meetingDate.widthAnchor.constraint(equalToConstant: 70.0),
+            meetingDate.heightAnchor.constraint(equalToConstant: 20.0),
+            
+            desc.topAnchor.constraint(equalTo: name.bottomAnchor, constant: 6.0),
+            desc.leadingAnchor.constraint(equalTo: name.leadingAnchor),
+            desc.widthAnchor.constraint(equalToConstant: 200.0),
+            desc.heightAnchor.constraint(equalToConstant: 20.0)
         ])
     }
 }

--- a/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
@@ -36,8 +36,6 @@ class MeetingsDetailViewController: UIViewController {
             
             self.openMapForPlace(lat: location.latitude, long: location.longitude)
         }
-        
-        
     }
     
     //Experimental mapping by address
@@ -70,9 +68,6 @@ class MeetingsDetailViewController: UIViewController {
         mapItem.name = "City Hall"
         mapItem.openInMaps(launchOptions: options)
     }
-    
-    
-    
     
     //MARK: - Setup and Layout
     private func setupView() {

--- a/publicmeetings-ios/Controllers/MinutesViewController.swift
+++ b/publicmeetings-ios/Controllers/MinutesViewController.swift
@@ -11,8 +11,7 @@ import UIKit
 class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
     //MARK: - Properties
-    var minutes: [String] = ["Zero","One","Two","Three","Four","Five","Six","Seven","Eight","Nine"]
-    
+    var allMeetings = [Meeting]()
     var tableView = UITableView()
     
     //MARK: - ViewController delegates
@@ -21,6 +20,8 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
         
         setupView()
         setupLayout()
+        
+        allMeetings = meetingData()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -29,7 +30,7 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
     
     //MARK: - TableView delegates
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        minutes.count
+        allMeetings.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -38,7 +39,10 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
         
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
-        cell.minutes.text = minutes[row]
+        
+        cell.name.text = allMeetings[row].title
+        cell.desc.text = allMeetings[row].description
+        cell.meetingDate.text = allMeetings[row].date
     
         return cell
     }
@@ -48,7 +52,7 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 120.0
+        return 60.0
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/publicmeetings-ios/SceneDelegate.swift
+++ b/publicmeetings-ios/SceneDelegate.swift
@@ -30,7 +30,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.


### PR DESCRIPTION
Update the Minutes screen so it's showing the same data from
the Meetings screen, which is actual data, but still not data
from a backend.

Note: All cells still load the minutes from a single sample file.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MinutesCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
	modified:   publicmeetings-ios/Controllers/MinutesViewController.swift
	modified:   publicmeetings-ios/SceneDelegate.swift