### PR TITLE
Agenda screen

### DIFF
--- a/publicmeetings-ios/Cells/AgendasCell.swift
+++ b/publicmeetings-ios/Cells/AgendasCell.swift
@@ -20,12 +20,31 @@ class AgendasCell: UITableViewCell {
         return v
     }()
     
-    var agendas: UILabel = {
+    var name: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .left
+        label.font = Standard.fontBold
+        label.baselineAdjustment = .alignCenters
+        return label
+    }()
+    
+    var desc: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = .black
         label.textAlignment = .left
         label.font = Standard.font
+        return label
+    }()
+    
+    var meetingDate: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .right
+        label.font = UIFont(name: "Damascus", size: 13.0)
         return label
     }()
     
@@ -48,7 +67,7 @@ class AgendasCell: UITableViewCell {
     
     //MARK: - Setup and Layout
     private func setupView() {
-        [view, agendas].forEach { contentView.addSubview($0) }
+        [view, name, desc, meetingDate].forEach { contentView.addSubview($0) }
     }
     
     private func setupLayout() {
@@ -58,10 +77,20 @@ class AgendasCell: UITableViewCell {
             view.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3.0),
             view.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -3.0),
             
-            agendas.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            agendas.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
-            agendas.widthAnchor.constraint(equalToConstant: 200.0),
-            agendas.heightAnchor.constraint(equalToConstant: 35.0)
+            name.topAnchor.constraint(equalTo: view.topAnchor, constant: 10.0),
+            name.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
+            name.widthAnchor.constraint(equalToConstant: 200.0),
+            name.heightAnchor.constraint(equalToConstant: 22.0),
+            
+            meetingDate.centerYAnchor.constraint(equalTo: name.centerYAnchor),
+            meetingDate.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -13.0),
+            meetingDate.widthAnchor.constraint(equalToConstant: 70.0),
+            meetingDate.heightAnchor.constraint(equalToConstant: 20.0),
+            
+            desc.topAnchor.constraint(equalTo: name.bottomAnchor, constant: 6.0),
+            desc.leadingAnchor.constraint(equalTo: name.leadingAnchor),
+            desc.widthAnchor.constraint(equalToConstant: 200.0),
+            desc.heightAnchor.constraint(equalToConstant: 20.0)
         ])
     }
 }

--- a/publicmeetings-ios/Controllers/AgendasViewController.swift
+++ b/publicmeetings-ios/Controllers/AgendasViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class AgendasViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
     //MARK: - Properties
+    var allMeetings = [Meeting]()
     var agendas: [String] = ["Zero","One","Two","Three","Four","Five","Six","Seven","Eight","Nine"]
     
     var tableView = UITableView()
@@ -21,6 +22,8 @@ class AgendasViewController: UIViewController, UITableViewDelegate, UITableViewD
         
         setupView()
         setupLayout()
+        
+        allMeetings = meetingData()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -38,7 +41,10 @@ class AgendasViewController: UIViewController, UITableViewDelegate, UITableViewD
         
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
-        cell.agendas.text = agendas[row]
+        
+        cell.name.text = allMeetings[row].title
+        cell.desc.text = allMeetings[row].description
+        cell.meetingDate.text = allMeetings[row].date
     
         return cell
     }
@@ -48,7 +54,7 @@ class AgendasViewController: UIViewController, UITableViewDelegate, UITableViewD
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 120.0
+        return 70.0
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/publicmeetings-ios/Controllers/MinutesViewController.swift
+++ b/publicmeetings-ios/Controllers/MinutesViewController.swift
@@ -52,7 +52,7 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 60.0
+        return 70.0
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
Update the Agenda screen so it's showing the same data from the
Meetings screen, which is actual data, but still not data from
a backend.

Note: All cells still load the agenda from a single sample file.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/AgendasCell.swift
	modified:   publicmeetings-ios/Controllers/AgendasViewController.swift
	modified:   publicmeetings-ios/Controllers/MinutesViewController.swift