### PR TITLE
Map Pass-through

### DIFF
--- a/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsDetailViewController.swift
@@ -35,6 +35,7 @@ class MeetingsDetailViewController: UIViewController {
             }
             
             self.openMapForPlace(lat: location.latitude, long: location.longitude)
+            self.dismiss(animated: false, completion: nil)
         }
     }
     


### PR DESCRIPTION
When loading Apple Maps from the Meetings screen, it passes
through the meeting detail screen.  This fix dismisses the
detail screen when Maps are loaded.

TODO: Dismissing the screen is not an ideal solution, in this
case.  A better solution needs to be implemented.  See issue #70.

Changes to be committed:
	modified:   publicmeetings-ios/Controllers/MeetingsDetailViewController.swift