### PR TITLE
Map screen

### DIFF
--- a/publicmeetings-ios/Controllers/MinutesViewController.swift
+++ b/publicmeetings-ios/Controllers/MinutesViewController.swift
@@ -22,7 +22,6 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
         setupLayout()
         
         allMeetings = meetingData()
-
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
As part of the fix for #70, I've moved the mapping code from
the detail screen to MeetingViewController (as an extension).
The mapping code is called from didSelectRow(_:).

The MeetingsDetailViewController is currently not being called.
If this fix turns out to be solid, that view controller can be removed.

Changes to be committed:
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/Controllers/MinutesViewController.swift