### PR TITLE
Meetings - Segmented control colors

### DIFF
--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -15,8 +15,10 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     var venue: UISegmentedControl = {
         let segmented = UISegmentedControl(items: ["All", "Wichita", "County", "State"])
         segmented.translatesAutoresizingMaskIntoConstraints = false
-        segmented.backgroundColor = UIColor(named: "devictBlue")
+        segmented.backgroundColor = UIColor.black
         segmented.selectedSegmentIndex = 0
+        segmented.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.black], for: UIControl.State.selected)
+        segmented.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: UIControl.State.normal)
         return segmented
     }()
     
@@ -37,7 +39,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        tabBarController?.tabBar.items?[0].badgeColor = UIColor(named: "devictBlue")
+        tabBarController?.tabBar.items?[0].badgeColor = UIColor(named: "softRed")
         tabBarController?.tabBar.items?[0].badgeValue = nil
 
         allMeetings = meetingData()


### PR DESCRIPTION
Change the colors for the segmented control on the Meetings screen.
Background is .black and the text is .white and .black for selected
and normal, respectively.

Changes to be committed:
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift