### PR TITLE
Rotation

### DIFF
--- a/publicmeetings-ios/AppDelegate.swift
+++ b/publicmeetings-ios/AppDelegate.swift
@@ -30,6 +30,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
-
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return .portrait
+    }
 }
 


### PR DESCRIPTION
Force orientation to be .portrait only.  The screens are informational
only and none of the screens would benefit from having the ability to
rotate.

Changes to be committed:
	modified:   publicmeetings-ios/AppDelegate.swift