### PR TITLE
Safe zone

### DIFF
--- a/publicmeetings-ios/Controllers/AboutViewController.swift
+++ b/publicmeetings-ios/Controllers/AboutViewController.swift
@@ -29,8 +29,10 @@ class AboutViewController: UIViewController {
     }
     
     private func setupLayout() {
+        let guide = view.safeAreaLayoutGuide
+        
         NSLayoutConstraint.activate([
-            aboutView.topAnchor.constraint(equalToSystemSpacingBelow: view.topAnchor, multiplier: 11.0),
+            aboutView.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 0.0),
             aboutView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             aboutView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             aboutView.bottomAnchor.constraint(equalTo: view.bottomAnchor)

--- a/publicmeetings-ios/Controllers/AgendasViewController.swift
+++ b/publicmeetings-ios/Controllers/AgendasViewController.swift
@@ -88,8 +88,10 @@ class AgendasViewController: UIViewController, UITableViewDelegate, UITableViewD
     }
      
      private func setupLayout() {
+         let guide = view.safeAreaLayoutGuide
+        
          NSLayoutConstraint.activate([
-             tableView.topAnchor.constraint(equalToSystemSpacingBelow: view.topAnchor, multiplier: 5.0),
+             tableView.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 0.0),
              tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
              tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15.0),
              tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -124,8 +124,10 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
     private func setupLayout() {
+        let guide = view.safeAreaLayoutGuide
+        
         NSLayoutConstraint.activate([
-            venue.topAnchor.constraint(equalToSystemSpacingBelow: view.topAnchor, multiplier: 11.0),
+            venue.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 0.0),
             venue.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             venue.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             venue.heightAnchor.constraint(equalToConstant: 30.0),

--- a/publicmeetings-ios/Controllers/MinutesViewController.swift
+++ b/publicmeetings-ios/Controllers/MinutesViewController.swift
@@ -89,8 +89,10 @@ class MinutesViewController: UIViewController, UITableViewDelegate, UITableViewD
     }
      
      private func setupLayout() {
+         let guide = view.safeAreaLayoutGuide
+        
          NSLayoutConstraint.activate([
-             tableView.topAnchor.constraint(equalToSystemSpacingBelow: view.topAnchor, multiplier: 5.0),
+             tableView.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 0.0),
              tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
              tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15.0),
              tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)

--- a/publicmeetings-ios/Controllers/MoreViewController.swift
+++ b/publicmeetings-ios/Controllers/MoreViewController.swift
@@ -105,11 +105,12 @@ class MoreViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     private func setupLayout() {
+        let guide = view.safeAreaLayoutGuide
+        
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalToSystemSpacingBelow: view.topAnchor, multiplier: 1.0),
+            tableView.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 1.0),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15.0),
-            tableView.widthAnchor.constraint(equalToConstant: Screen.width),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
     }

--- a/publicmeetings-ios/Controllers/SearchViewController.swift
+++ b/publicmeetings-ios/Controllers/SearchViewController.swift
@@ -42,8 +42,10 @@ class SearchViewController: UIViewController {
     }
     
     private func setupLayout() {
+        let guide = view.safeAreaLayoutGuide
+        
         NSLayoutConstraint.activate([
-            searchView.topAnchor.constraint(equalToSystemSpacingBelow: view.topAnchor, multiplier: 11.0),
+            searchView.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 0.0),
             searchView.widthAnchor.constraint(equalToConstant: Screen.width),
             searchView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])


### PR DESCRIPTION
Handle the safe zone in the constraints for the view controllers.
On a previous commit, the orientation was changed to portrait only,
so finishing up by handling the top constraint in relation to the
safe zone for those devices that have one.

Changes to be committed:
	modified:   publicmeetings-ios/Controllers/AboutViewController.swift
	modified:   publicmeetings-ios/Controllers/AgendasViewController.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/Controllers/MinutesViewController.swift
	modified:   publicmeetings-ios/Controllers/MoreViewController.swift
	modified:   publicmeetings-ios/Controllers/SearchViewController.swift