### PR TITLE
Font issue

### DIFF
--- a/publicmeetings-ios/Constants/StandardValues.swift
+++ b/publicmeetings-ios/Constants/StandardValues.swift
@@ -12,6 +12,7 @@ import UIKit
 struct Standard {
     static let cornerRadius: CGFloat = 8.0
     static let font: UIFont = UIFont(name: "Damascus", size: 16.0)!
+    static let systemFont: UIFont = UIFont.systemFont(ofSize: 16.0)
     static let fontBold: UIFont = UIFont(name: "DamascusBold", size: 16.0)!
     static let largeFont: UIFont = UIFont(name: "Damascus", size: 40.0)!
 }

--- a/publicmeetings-ios/Views/AboutView.swift
+++ b/publicmeetings-ios/Views/AboutView.swift
@@ -22,7 +22,7 @@ class AboutView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = "Developed By"
-        label.font = Standard.font
+        label.font = Standard.systemFont
         label.textAlignment = .center
         return label
     }()
@@ -31,7 +31,7 @@ class AboutView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = "Michael Campbell"
-        label.font = Standard.font
+        label.font = Standard.systemFont
         label.textAlignment = .center
         return label
     }()
@@ -62,7 +62,7 @@ class AboutView: UIView {
         NSLayoutConstraint.activate([
             logo.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 30.0),
             logo.centerXAnchor.constraint(equalTo: centerXAnchor),
-            logo.widthAnchor.constraint(equalToConstant: Screen.width * 0.75),
+            logo.widthAnchor.constraint(equalToConstant: Screen.width * 0.65),
             
             developedBy.topAnchor.constraint(equalTo: bottomAnchor, constant: -70.0),
             developedBy.centerXAnchor.constraint(equalTo: centerXAnchor),


### PR DESCRIPTION
There are instances where the font is getting truncated at the top
of labels.  The issue is due to the font being used (Dasmascus),
which was chosen at random.  Changing to the systemFont fixes the
problem, so either stick with that or look for a font that doesn't
cause truncation.

Changes to be committed:
	modified:   publicmeetings-ios/Constants/StandardValues.swift
	modified:   publicmeetings-ios/Views/AboutView.swift