### PR TITLE
Documents

### DIFF
--- a/publicmeetings-ios.xcodeproj/project.pbxproj
+++ b/publicmeetings-ios.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		E512C19D23445BD6005BF52E /* Meeting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E512C19C23445BD6005BF52E /* Meeting.swift */; };
 		E514FAAC2347330D00075816 /* MeetingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E514FAAB2347330D00075816 /* MeetingCell.swift */; };
 		E51FA4A72344DFF6005C5091 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51FA4A62344DFF6005C5091 /* TabBarController.swift */; };
+		E51FD2D32386A7D70054AD8A /* DocumentsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51FD2D22386A7D70054AD8A /* DocumentsViewController.swift */; };
+		E51FD2D52386A7F20054AD8A /* DocumentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51FD2D42386A7F20054AD8A /* DocumentsView.swift */; };
+		E51FD2D72386AC7B0054AD8A /* MinutesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51FD2D62386AC7B0054AD8A /* MinutesView.swift */; };
+		E51FD2D92386AC910054AD8A /* AgendasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51FD2D82386AC910054AD8A /* AgendasView.swift */; };
 		E52268532353945F0036163B /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52268522353945F0036163B /* SearchView.swift */; };
 		E522685C23540F5D0036163B /* CreateMeetingData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E522685B23540F5D0036163B /* CreateMeetingData.swift */; };
 		E525261923490A150003B575 /* devict-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = E525261823490A150003B575 /* devict-logo.png */; };
@@ -40,6 +44,7 @@
 		E56A792F2361E126001376EC /* AgendasViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56A792E2361E126001376EC /* AgendasViewController.swift */; };
 		E56A79312361E137001376EC /* AgendasCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56A79302361E137001376EC /* AgendasCell.swift */; };
 		E580F2C42377BFCD00F0C0FD /* devict-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = E580F2C32377BFCD00F0C0FD /* devict-icon.png */; };
+		E5A88D42239219C200610157 /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A88D41239219C200610157 /* UIApplication.swift */; };
 		E5F0305C23631EC400F65234 /* NoMeetingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F0305B23631EC400F65234 /* NoMeetingsView.swift */; };
 /* End PBXBuildFile section */
 
@@ -72,6 +77,10 @@
 		E512C19C23445BD6005BF52E /* Meeting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Meeting.swift; sourceTree = "<group>"; };
 		E514FAAB2347330D00075816 /* MeetingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCell.swift; sourceTree = "<group>"; };
 		E51FA4A62344DFF6005C5091 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		E51FD2D22386A7D70054AD8A /* DocumentsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentsViewController.swift; sourceTree = "<group>"; };
+		E51FD2D42386A7F20054AD8A /* DocumentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentsView.swift; sourceTree = "<group>"; };
+		E51FD2D62386AC7B0054AD8A /* MinutesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinutesView.swift; sourceTree = "<group>"; };
+		E51FD2D82386AC910054AD8A /* AgendasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgendasView.swift; sourceTree = "<group>"; };
 		E52268522353945F0036163B /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		E522685B23540F5D0036163B /* CreateMeetingData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetingData.swift; sourceTree = "<group>"; };
 		E525261823490A150003B575 /* devict-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "devict-logo.png"; sourceTree = "<group>"; };
@@ -100,6 +109,7 @@
 		E56A792E2361E126001376EC /* AgendasViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgendasViewController.swift; sourceTree = "<group>"; };
 		E56A79302361E137001376EC /* AgendasCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgendasCell.swift; sourceTree = "<group>"; };
 		E580F2C32377BFCD00F0C0FD /* devict-icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "devict-icon.png"; sourceTree = "<group>"; };
+		E5A88D41239219C200610157 /* UIApplication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIApplication.swift; sourceTree = "<group>"; };
 		E5F0305B23631EC400F65234 /* NoMeetingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoMeetingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -132,7 +142,10 @@
 			isa = PBXGroup;
 			children = (
 				E508086B23670CF2007DC949 /* AboutView.swift */,
+				E51FD2D82386AC910054AD8A /* AgendasView.swift */,
+				E51FD2D42386A7F20054AD8A /* DocumentsView.swift */,
 				E511CFE9234A8D4800807CAF /* MeetingsDetailView.swift */,
+				E51FD2D62386AC7B0054AD8A /* MinutesView.swift */,
 				E5F0305B23631EC400F65234 /* NoMeetingsView.swift */,
 				E52268522353945F0036163B /* SearchView.swift */,
 			);
@@ -182,6 +195,7 @@
 			children = (
 				E508086923670CD8007DC949 /* AboutViewController.swift */,
 				E56A792E2361E126001376EC /* AgendasViewController.swift */,
+				E51FD2D22386A7D70054AD8A /* DocumentsViewController.swift */,
 				E52E43D923485B3600DF9D5B /* MeetingsViewController.swift */,
 				E511CFF2234ACD8D00807CAF /* MinutesViewController.swift */,
 				E52E43D5234854CA00DF9D5B /* MoreViewController.swift */,
@@ -241,6 +255,7 @@
 		E54DA36B234431E60070241F /* publicmeetings-ios */ = {
 			isa = PBXGroup;
 			children = (
+				E5A88D402392199D00610157 /* Extensions */,
 				E53623B3236131E100020413 /* WebView */,
 				E522685A23540D7C0036163B /* Utils */,
 				E511CFEB234A8EB100807CAF /* Constants */,
@@ -276,6 +291,14 @@
 				E54DA390234431E70070241F /* Info.plist */,
 			);
 			path = "publicmeetings-iosUITests";
+			sourceTree = "<group>";
+		};
+		E5A88D402392199D00610157 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E5A88D41239219C200610157 /* UIApplication.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -421,17 +444,22 @@
 				E56077AB235C9AEB003D8F26 /* StandardValues.swift in Sources */,
 				E52E43DA23485B3600DF9D5B /* MeetingsViewController.swift in Sources */,
 				E508086A23670CD8007DC949 /* AboutViewController.swift in Sources */,
+				E51FD2D52386A7F20054AD8A /* DocumentsView.swift in Sources */,
 				E511CFEA234A8D4800807CAF /* MeetingsDetailView.swift in Sources */,
 				E54DA36D234431E60070241F /* AppDelegate.swift in Sources */,
 				E511CFEE234A8EE700807CAF /* Accuracy.swift in Sources */,
+				E51FD2D32386A7D70054AD8A /* DocumentsViewController.swift in Sources */,
 				E52268532353945F0036163B /* SearchView.swift in Sources */,
+				E51FD2D72386AC7B0054AD8A /* MinutesView.swift in Sources */,
 				E51FA4A72344DFF6005C5091 /* TabBarController.swift in Sources */,
 				E53623B5236131F100020413 /* WebViewer.swift in Sources */,
 				E52E43D6234854CA00DF9D5B /* MoreViewController.swift in Sources */,
 				E54DA36F234431E60070241F /* SceneDelegate.swift in Sources */,
+				E51FD2D92386AC910054AD8A /* AgendasView.swift in Sources */,
 				E52958822353145A00E1F2D7 /* SearchViewController.swift in Sources */,
 				E5F0305C23631EC400F65234 /* NoMeetingsView.swift in Sources */,
 				E514FAAC2347330D00075816 /* MeetingCell.swift in Sources */,
+				E5A88D42239219C200610157 /* UIApplication.swift in Sources */,
 				E508086C23670CF2007DC949 /* AboutView.swift in Sources */,
 				E511CFF5234ACE5800807CAF /* MinutesCell.swift in Sources */,
 				E525261B234911070003B575 /* MoreCell.swift in Sources */,

--- a/publicmeetings-ios/Colors.xcassets/devictTan.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/devictTan.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.921",
+          "red" : "235",
           "alpha" : "1.000",
-          "blue" : "0.882",
-          "green" : "0.913"
+          "blue" : "225",
+          "green" : "233"
         }
       }
     }

--- a/publicmeetings-ios/Controllers/DocumentsViewController.swift
+++ b/publicmeetings-ios/Controllers/DocumentsViewController.swift
@@ -1,0 +1,55 @@
+//
+//  DocumentsViewController.swift
+//  publicmeetings-ios
+//
+//  Created by mpc on 11/21/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+class DocumentsViewController: UIViewController {
+
+    var documentsView: DocumentsView = {
+        let view = DocumentsView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = UIColor(named: "devictTan")
+        
+        setupView()
+        setupLayout()
+        setScreenTitle()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        setScreenTitle()
+        navigationController?.navigationBar.barTintColor = .systemPurple
+    }
+    
+    //MARK: - Setup and Layout
+    private func setScreenTitle() {
+        DispatchQueue.main.async {
+            self.tabBarController?.navigationItem.title = "Agendas"
+        }
+    }
+    
+    private func setupView() {
+        view.addSubview(documentsView)
+    }
+    
+    private func setupLayout() {
+        let guide = view.safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+            documentsView.topAnchor.constraint(equalTo: guide.topAnchor, constant: 0.0),
+            documentsView.leadingAnchor.constraint(equalTo: guide.leadingAnchor),
+            documentsView.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
+            documentsView.bottomAnchor.constraint(equalTo: guide.bottomAnchor)
+        ])
+    }
+}

--- a/publicmeetings-ios/Controllers/MoreViewController.swift
+++ b/publicmeetings-ios/Controllers/MoreViewController.swift
@@ -63,7 +63,6 @@ class MoreViewController: UIViewController, UITableViewDelegate, UITableViewData
         if let currentItem = currentCell.item.text {
             if currentItem == "Voter Registration" {
                 let url = "http://www.voteks.org/before-you-vote/how-do-i-register.html"
-                        
                 let viewController = WebViewer()
                 viewController.documentUrl = url
                 
@@ -74,7 +73,6 @@ class MoreViewController: UIViewController, UITableViewDelegate, UITableViewData
             
             if currentItem == "Election Schedule" {
                 let url = "https://ballotpedia.org/City_elections_in_Wichita,_Kansas_(2019)"
-                          
                 let viewController = WebViewer()
                 viewController.documentUrl = url
                  
@@ -85,7 +83,6 @@ class MoreViewController: UIViewController, UITableViewDelegate, UITableViewData
             
             if currentItem == "Donate" {
                 let url = "http://devict.org/support"
-                          
                 let viewController = WebViewer()
                 viewController.documentUrl = url
                  

--- a/publicmeetings-ios/Extensions/UIApplication.swift
+++ b/publicmeetings-ios/Extensions/UIApplication.swift
@@ -1,0 +1,21 @@
+//
+//  UIApplication.swift
+//  TruColor
+//
+//  Created by mpc on 11/29/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+extension UIApplication {
+    static func topViewController() -> UIViewController? {
+        guard var top = shared.keyWindow?.rootViewController else {
+            return nil
+        }
+        while let next = top.presentedViewController {
+            top = next
+        }
+        return top
+    }
+}

--- a/publicmeetings-ios/TabBar/TabBarController.swift
+++ b/publicmeetings-ios/TabBar/TabBarController.swift
@@ -15,6 +15,7 @@ class TabBarController: UITabBarController {
 
         //MARK: - Properties
         let meetingsViewController = MeetingsViewController()
+        let documentsViewController = DocumentsViewController()
         let minutesViewController = MinutesViewController()
         let agendaViewController = AgendasViewController()
         let searchViewController = SearchViewController()
@@ -23,27 +24,33 @@ class TabBarController: UITabBarController {
         //MARK: - TabBar image setup
         let config = UIImage.SymbolConfiguration(weight: .heavy)
         let meetingImage = UIImage(systemName: "calendar", withConfiguration: config)
+        let documentsImage = UIImage(systemName: "folder", withConfiguration: config)
         let minutesImage = UIImage(systemName: "clock", withConfiguration: config)
         let agendaImage = UIImage(systemName: "list.number", withConfiguration: config)
         let searchImage = UIImage(systemName: "magnifyingglass", withConfiguration: config)
+        let docImage = UIImage(systemName: "doc.plaintext", withConfiguration: config)
         let moreImage = UIImage(systemName: "ellipsis.circle", withConfiguration: config)
         
         //MARK: - TabBar item setup
         meetingsViewController.tabBarItem = UITabBarItem(title: "Meetings", image: meetingImage, selectedImage: meetingImage)
+        documentsViewController.tabBarItem = UITabBarItem(title: "Documents", image: documentsImage, selectedImage: documentsImage)
         minutesViewController.tabBarItem = UITabBarItem(title: "Minutes", image: minutesImage, selectedImage: minutesImage)
         agendaViewController.tabBarItem = UITabBarItem(title: "Agendas", image: agendaImage, selectedImage: agendaImage)
         searchViewController.tabBarItem = UITabBarItem(title: "Search", image: searchImage, selectedImage: searchImage)
+        documentsViewController.tabBarItem = UITabBarItem(title: "Documents", image: docImage, selectedImage: docImage)
         moreViewController.tabBarItem = UITabBarItem(title: "More", image: moreImage, selectedImage: moreImage)
         
         //MARK: - Navigation
         meetingsViewController.navigationController?.navigationBar.topItem?.title = "Meetings"
+        documentsViewController.navigationController?.navigationBar.topItem?.title = "Documents"
         minutesViewController.navigationController?.navigationBar.topItem?.title = "Minutes"
         minutesViewController.navigationController?.navigationBar.topItem?.title = "Agendas"
         searchViewController.navigationController?.navigationBar.topItem?.title = "Search"
+        documentsViewController.navigationController?.navigationBar.topItem?.title = "Documents"
         moreViewController.navigationController?.navigationBar.topItem?.title = "More"
          
         //MARK: - ViewController configuration
-        let viewControllerList = [meetingsViewController, minutesViewController, agendaViewController, searchViewController, moreViewController]
+        let viewControllerList = [meetingsViewController, documentsViewController, searchViewController, moreViewController]
         viewControllers = viewControllerList
         
         //MARK: - TabBar configuration

--- a/publicmeetings-ios/Views/AgendasView.swift
+++ b/publicmeetings-ios/Views/AgendasView.swift
@@ -1,0 +1,44 @@
+//
+//  AgendasView.swift
+//  publicmeetings-ios
+//
+//  Created by mpc on 11/21/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+class AgendasView: UIView {
+
+    //MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupView()
+        setupLayout()
+        setupActions()
+    }
+     
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    //MARK: - Setup and Layout
+    private func setupView() {
+
+    }
+    
+    private func setupLayout() {
+        let guide = safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+        
+        
+        ])
+    }
+    
+    private func setupActions() {
+        
+    }
+
+}

--- a/publicmeetings-ios/Views/DocumentsView.swift
+++ b/publicmeetings-ios/Views/DocumentsView.swift
@@ -1,0 +1,109 @@
+//
+//  DocumentsView.swift
+//  publicmeetings-ios
+//
+//  Created by mpc on 11/21/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+class DocumentsView: UIView, UITableViewDelegate, UITableViewDataSource {
+
+    //MARK: - Properties
+    var docType: UISegmentedControl = {
+        let segmented = UISegmentedControl(items: ["Agendas", "Minutes"])
+        segmented.translatesAutoresizingMaskIntoConstraints = false
+        segmented.backgroundColor = UIColor.black
+        segmented.selectedSegmentIndex = 0
+        segmented.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.black], for: UIControl.State.selected)
+        segmented.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: UIControl.State.normal)
+        segmented.layer.borderColor = UIColor.white.cgColor
+        segmented.layer.borderWidth = 0.9
+        return segmented
+    }()
+    
+    var allMeetings = [Meeting]()
+    var tableView = UITableView()
+    
+    //MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupView()
+        setupLayout()
+        
+        allMeetings = meetingData()
+        print("allMeetings: \(allMeetings)")
+    }
+     
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    //MARK: - TableView delegates
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        allMeetings.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "minutesCell") as! MinutesCell
+        let row = indexPath.row
+        
+        cell.name.text = allMeetings[row].title
+        cell.desc.text = allMeetings[row].description
+        cell.meetingDate.text = allMeetings[row].date
+    
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        cell.contentView.layer.masksToBounds = true
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 70.0
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let url = "http://wichitaks.granicus.com/MinutesViewer.php?view_id=2&clip_id=3883"
+        
+        let viewController = WebViewer()
+        viewController.documentUrl = url
+        
+        DispatchQueue.main.async {
+            UIApplication.topViewController()?.present(viewController, animated: true, completion: nil)
+        }
+    }
+    
+    
+    //MARK: - Setup and Layout
+    private func setupView() {
+        [docType, tableView].forEach { addSubview($0) }
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(MinutesCell.self, forCellReuseIdentifier: "minutesCell")
+    }
+    
+    private func setupLayout() {
+        let guide = safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+            docType.topAnchor.constraint(equalTo: topAnchor),
+            docType.leadingAnchor.constraint(equalTo: leadingAnchor),
+            docType.trailingAnchor.constraint(equalTo: trailingAnchor),
+            docType.heightAnchor.constraint(equalToConstant: 31.0),
+            
+            tableView.topAnchor.constraint(equalTo: docType.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 15.0),
+            tableView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -15.0),
+            tableView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+    private func setupActions() {
+        
+    }
+}

--- a/publicmeetings-ios/Views/MinutesView.swift
+++ b/publicmeetings-ios/Views/MinutesView.swift
@@ -1,0 +1,47 @@
+//
+//  MinutesView.swift
+//  publicmeetings-ios
+//
+//  Created by mpc on 11/21/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+class MinutesView: UIView {
+
+    //MARK: - Properties
+    var allMeetings = [Meeting]()
+    var tableView = UITableView()
+    
+    //MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupView()
+        setupLayout()
+        setupActions()
+    }
+     
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    //MARK: - Setup and Layout
+    private func setupView() {
+
+    }
+    
+    private func setupLayout() {
+        let guide = safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+        
+        
+        ])
+    }
+    
+    private func setupActions() {
+        
+    }
+}


### PR DESCRIPTION
Create Documents screens (view and view controller).  The Minutes
and Agenda screens are basically the same.  They only point to
different URLs.  The documents screen will combine both into one
screen (and be replaced on the tab bar).  A segmented control will
drive the data source that is displayed.

This commit serves as the first step.  Logic needs to be added to
switch from Minutes to Agendas.  Additionally, the cells for each
need to be combined into one, so that the tableView.register(_:)
is dynamic and everything from the ViewController to the Cell has
no static information (reuseIdentifier, etc).

Changes to be committed:
	modified:   publicmeetings-ios.xcodeproj/project.pbxproj
	modified:   publicmeetings-ios/Colors.xcassets/devictTan.colorset/Contents.json
	new file:   publicmeetings-ios/Controllers/DocumentsViewController.swift
	modified:   publicmeetings-ios/Controllers/MoreViewController.swift
	new file:   publicmeetings-ios/Extensions/UIApplication.swift
	modified:   publicmeetings-ios/TabBar/TabBarController.swift
	new file:   publicmeetings-ios/Views/AgendasView.swift
	new file:   publicmeetings-ios/Views/DocumentsView.swift
	new file:   publicmeetings-ios/Views/MinutesView.swift