### PR TITLE
Documents new design

### DIFF
--- a/publicmeetings-ios.xcodeproj/project.pbxproj
+++ b/publicmeetings-ios.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		E56A79312361E137001376EC /* AgendasCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56A79302361E137001376EC /* AgendasCell.swift */; };
 		E580F2C42377BFCD00F0C0FD /* devict-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = E580F2C32377BFCD00F0C0FD /* devict-icon.png */; };
 		E5A88D42239219C200610157 /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A88D41239219C200610157 /* UIApplication.swift */; };
+		E5A88D44239237D800610157 /* DocumentsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A88D43239237D800610157 /* DocumentsCell.swift */; };
 		E5F0305C23631EC400F65234 /* NoMeetingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F0305B23631EC400F65234 /* NoMeetingsView.swift */; };
 /* End PBXBuildFile section */
 
@@ -110,6 +111,7 @@
 		E56A79302361E137001376EC /* AgendasCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgendasCell.swift; sourceTree = "<group>"; };
 		E580F2C32377BFCD00F0C0FD /* devict-icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "devict-icon.png"; sourceTree = "<group>"; };
 		E5A88D41239219C200610157 /* UIApplication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIApplication.swift; sourceTree = "<group>"; };
+		E5A88D43239237D800610157 /* DocumentsCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentsCell.swift; sourceTree = "<group>"; };
 		E5F0305B23631EC400F65234 /* NoMeetingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoMeetingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -174,9 +176,10 @@
 		E514FAAA234732E500075816 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				E56A79302361E137001376EC /* AgendasCell.swift */,
+				E5A88D43239237D800610157 /* DocumentsCell.swift */,
 				E514FAAB2347330D00075816 /* MeetingCell.swift */,
 				E511CFF4234ACE5800807CAF /* MinutesCell.swift */,
-				E56A79302361E137001376EC /* AgendasCell.swift */,
 				E525261A234911070003B575 /* MoreCell.swift */,
 			);
 			path = Cells;
@@ -461,6 +464,7 @@
 				E514FAAC2347330D00075816 /* MeetingCell.swift in Sources */,
 				E5A88D42239219C200610157 /* UIApplication.swift in Sources */,
 				E508086C23670CF2007DC949 /* AboutView.swift in Sources */,
+				E5A88D44239237D800610157 /* DocumentsCell.swift in Sources */,
 				E511CFF5234ACE5800807CAF /* MinutesCell.swift in Sources */,
 				E525261B234911070003B575 /* MoreCell.swift in Sources */,
 				E511CFF3234ACD8D00807CAF /* MinutesViewController.swift in Sources */,

--- a/publicmeetings-ios/Cells/DocumentsCell.swift
+++ b/publicmeetings-ios/Cells/DocumentsCell.swift
@@ -1,0 +1,148 @@
+//
+//  DocumentsCell.swift
+//  publicmeetings-ios
+//
+//  Created by mpc on 10/6/19.
+//  Copyright © 2019 mpc. All rights reserved.
+//
+
+import UIKit
+
+class DocumentsCell: UITableViewCell {
+
+    var view: UIView = {
+        let v = UIView()
+        v.translatesAutoresizingMaskIntoConstraints = false
+        v.backgroundColor = .white
+        v.layer.borderColor = UIColor.black.cgColor
+        v.layer.borderWidth = 0.3
+        v.clipsToBounds = true
+        return v
+    }()
+    
+    var name: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .left
+        label.font = Standard.fontBold
+        label.baselineAdjustment = .alignCenters
+        return label
+    }()
+    
+    var desc: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .left
+        label.font = Standard.font
+        return label
+    }()
+    
+    var meetingDate: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
+        label.textAlignment = .right
+        label.font = UIFont(name: "Damascus", size: 13.0)
+        return label
+    }()
+    
+    var minutesButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Minutes", for: .normal)
+        button.layer.borderColor = UIColor.black.cgColor
+        button.layer.borderWidth = 0.9
+        button.setTitleColor(.black, for: .normal)
+        button.layer.cornerRadius = 8.0
+        return button
+    }()
+    
+    var agendaButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Agenda", for: .normal)
+        button.layer.borderColor = UIColor.black.cgColor
+        button.layer.borderWidth = 0.9
+        button.setTitleColor(.black, for: .normal)
+        button.layer.cornerRadius = 8.0
+        return button
+    }()
+    
+    
+    
+    //MARK: - Initialization
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+            
+        setupView()
+        setupLayout()
+        setupActions()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+    
+    //MARK: - Setup and Layout
+    private func setupView() {
+        [view, name, desc, meetingDate, minutesButton, agendaButton].forEach { contentView.addSubview($0) }
+        
+        selectionStyle = .none
+        backgroundColor = .clear
+    }
+    
+    private func setupLayout() {
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: topAnchor, constant: 3.0),
+            view.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 3.0),
+            view.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3.0),
+            view.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -3.0),
+            
+            name.topAnchor.constraint(equalTo: view.topAnchor, constant: 10.0),
+            name.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0),
+            name.widthAnchor.constraint(equalToConstant: 200.0),
+            name.heightAnchor.constraint(equalToConstant: 22.0),
+            
+            meetingDate.centerYAnchor.constraint(equalTo: name.centerYAnchor),
+            meetingDate.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -13.0),
+            meetingDate.widthAnchor.constraint(equalToConstant: 70.0),
+            meetingDate.heightAnchor.constraint(equalToConstant: 20.0),
+            
+            desc.topAnchor.constraint(equalTo: name.bottomAnchor, constant: 6.0),
+            desc.leadingAnchor.constraint(equalTo: name.leadingAnchor),
+            desc.widthAnchor.constraint(equalToConstant: 200.0),
+            desc.heightAnchor.constraint(equalToConstant: 20.0),
+            
+            minutesButton.topAnchor.constraint(equalTo: desc.bottomAnchor, constant: 10.0),
+            minutesButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 15.0),
+            minutesButton.widthAnchor.constraint(equalToConstant: 120.0),
+            minutesButton.heightAnchor.constraint(equalToConstant: 40.0),
+            
+            agendaButton.topAnchor.constraint(equalTo: desc.bottomAnchor, constant: 10.0),
+            agendaButton.leadingAnchor.constraint(equalTo: minutesButton.trailingAnchor, constant: 15.0),
+            agendaButton.widthAnchor.constraint(equalToConstant: 120.0),
+            agendaButton.heightAnchor.constraint(equalToConstant: 40.0)            
+        ])
+    }
+    
+    func setupActions() {
+        minutesButton.addTarget(self, action: #selector(minutesButtonTapped(sender:)), for: .touchUpInside)
+        agendaButton.addTarget(self, action: #selector(agendaButtonTapped(sender:)), for: .touchUpInside)
+    }
+    
+    
+    //MARK: - Actions
+    @objc func minutesButtonTapped(sender: UIButton) {
+        print("minutesButtonTapped")
+    }
+    
+    @objc func agendaButtonTapped(sender: UIButton) {
+        print("agendaButtonTapped")
+    }    
+}

--- a/publicmeetings-ios/Views/DocumentsView.swift
+++ b/publicmeetings-ios/Views/DocumentsView.swift
@@ -11,18 +11,6 @@ import UIKit
 class DocumentsView: UIView, UITableViewDelegate, UITableViewDataSource {
 
     //MARK: - Properties
-    var docType: UISegmentedControl = {
-        let segmented = UISegmentedControl(items: ["Agendas", "Minutes"])
-        segmented.translatesAutoresizingMaskIntoConstraints = false
-        segmented.backgroundColor = UIColor.black
-        segmented.selectedSegmentIndex = 0
-        segmented.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.black], for: UIControl.State.selected)
-        segmented.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: UIControl.State.normal)
-        segmented.layer.borderColor = UIColor.white.cgColor
-        segmented.layer.borderWidth = 0.9
-        return segmented
-    }()
-    
     var allMeetings = [Meeting]()
     var tableView = UITableView()
     
@@ -34,7 +22,6 @@ class DocumentsView: UIView, UITableViewDelegate, UITableViewDataSource {
         setupLayout()
         
         allMeetings = meetingData()
-        print("allMeetings: \(allMeetings)")
     }
      
     required init?(coder aDecoder: NSCoder) {
@@ -47,7 +34,7 @@ class DocumentsView: UIView, UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "minutesCell") as! MinutesCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "documentsCell") as! DocumentsCell
         let row = indexPath.row
         
         cell.name.text = allMeetings[row].title
@@ -62,7 +49,7 @@ class DocumentsView: UIView, UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 70.0
+        return 140.0
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -79,24 +66,19 @@ class DocumentsView: UIView, UITableViewDelegate, UITableViewDataSource {
     
     //MARK: - Setup and Layout
     private func setupView() {
-        [docType, tableView].forEach { addSubview($0) }
-        tableView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(tableView)
         
+        tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.register(MinutesCell.self, forCellReuseIdentifier: "minutesCell")
+        tableView.register(DocumentsCell.self, forCellReuseIdentifier: "documentsCell")
     }
     
     private func setupLayout() {
         let guide = safeAreaLayoutGuide
         
         NSLayoutConstraint.activate([
-            docType.topAnchor.constraint(equalTo: topAnchor),
-            docType.leadingAnchor.constraint(equalTo: leadingAnchor),
-            docType.trailingAnchor.constraint(equalTo: trailingAnchor),
-            docType.heightAnchor.constraint(equalToConstant: 31.0),
-            
-            tableView.topAnchor.constraint(equalTo: docType.bottomAnchor),
+            tableView.topAnchor.constraint(equalTo: topAnchor),
             tableView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 15.0),
             tableView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -15.0),
             tableView.bottomAnchor.constraint(equalTo: bottomAnchor)


### PR DESCRIPTION
Rethought the idea of the documents screen.  Instead of a segmented
control to switch between Minutes and Agenda documents, added a button
on the cell for both.  The segmented control has been removed.  The
buttons can use a bit of sprucing up.  They're just placeholders for
the time being.

Changes to be committed:
	modified:   publicmeetings-ios.xcodeproj/project.pbxproj
	new file:   publicmeetings-ios/Cells/DocumentsCell.swift
	modified:   publicmeetings-ios/Views/DocumentsView.swift