### PR TITLE
Documents screen

### DIFF
--- a/publicmeetings-ios/Cells/DocumentsCell.swift
+++ b/publicmeetings-ios/Cells/DocumentsCell.swift
@@ -127,7 +127,7 @@ class DocumentsCell: UITableViewCell {
             minutesButton.heightAnchor.constraint(equalToConstant: 40.0),
             
             agendaButton.topAnchor.constraint(equalTo: desc.bottomAnchor, constant: 10.0),
-            agendaButton.leadingAnchor.constraint(equalTo: minutesButton.trailingAnchor, constant: 15.0),
+            agendaButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -15.0),
             agendaButton.widthAnchor.constraint(equalToConstant: 120.0),
             agendaButton.heightAnchor.constraint(equalToConstant: 40.0)            
         ])

--- a/publicmeetings-ios/Views/DocumentsView.swift
+++ b/publicmeetings-ios/Views/DocumentsView.swift
@@ -71,6 +71,8 @@ class DocumentsView: UIView, UITableViewDelegate, UITableViewDataSource {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.separatorStyle = .none
+        tableView.backgroundColor = .clear
         tableView.register(DocumentsCell.self, forCellReuseIdentifier: "documentsCell")
     }
     


### PR DESCRIPTION
Make the Documents tableView look like the tableviews on the other
screens (remove separator and background is clear).

Put the buttons so they are equidistant from the leading and trailing anchors.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/DocumentsCell.swift
	modified:   publicmeetings-ios/Views/DocumentsView.swift