### PR TITLE
Code cleanup

### DIFF
--- a/publicmeetings-ios/Extensions/UIApplication.swift
+++ b/publicmeetings-ios/Extensions/UIApplication.swift
@@ -13,9 +13,11 @@ extension UIApplication {
         guard var top = shared.keyWindow?.rootViewController else {
             return nil
         }
+        
         while let next = top.presentedViewController {
             top = next
         }
+        
         return top
     }
 }

--- a/publicmeetings-ios/TabBar/TabBarController.swift
+++ b/publicmeetings-ios/TabBar/TabBarController.swift
@@ -24,7 +24,6 @@ class TabBarController: UITabBarController {
         let meetingImage = UIImage(systemName: "calendar", withConfiguration: config)
         let documentsImage = UIImage(systemName: "folder", withConfiguration: config)
         let searchImage = UIImage(systemName: "magnifyingglass", withConfiguration: config)
-        let docImage = UIImage(systemName: "doc.plaintext", withConfiguration: config)
         let moreImage = UIImage(systemName: "ellipsis.circle", withConfiguration: config)
         
         //MARK: - TabBar item setup

--- a/publicmeetings-ios/Views/DocumentsView.swift
+++ b/publicmeetings-ios/Views/DocumentsView.swift
@@ -77,8 +77,6 @@ class DocumentsView: UIView, UITableViewDelegate, UITableViewDataSource {
     }
     
     private func setupLayout() {
-        let guide = safeAreaLayoutGuide
-        
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: topAnchor),
             tableView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 15.0),


### PR DESCRIPTION
Fix some of the warnings when building.

TODO:
    keyWindow is deprecated for iOS 13.  Need to replace this in the
UIApplication extension.

    Need to add xcassets for various app icon sizes.

Neither of these issues cause breakage.

Changes to be committed:
	modified:   publicmeetings-ios/Extensions/UIApplication.swift
	modified:   publicmeetings-ios/TabBar/TabBarController.swift
	modified:   publicmeetings-ios/Views/DocumentsView.swift