### PR TITLE
Navigation Bar Color

### DIFF
--- a/publicmeetings-ios/Cells/DocumentsCell.swift
+++ b/publicmeetings-ios/Cells/DocumentsCell.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class DocumentsCell: UITableViewCell {
 
+    //MARK: - Properties
     var view: UIView = {
         let v = UIView()
         v.translatesAutoresizingMaskIntoConstraints = false
@@ -56,6 +57,7 @@ class DocumentsCell: UITableViewCell {
         button.layer.borderColor = UIColor.black.cgColor
         button.layer.borderWidth = 0.9
         button.setTitleColor(.black, for: .normal)
+        button.backgroundColor = UIColor(named: "devictTan")
         button.layer.cornerRadius = 12.0
         return button
     }()
@@ -68,14 +70,14 @@ class DocumentsCell: UITableViewCell {
         button.layer.borderColor = UIColor.black.cgColor
         button.layer.borderWidth = 0.9
         button.setTitleColor(.black, for: .normal)
+        button.backgroundColor = UIColor(named: "devictTan")
         button.layer.cornerRadius = 12.0
         return button
     }()
     
     var minutesUrl: String = ""
     var agendaUrl: String = ""
-    
-    
+        
     //MARK: - Initialization
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -139,7 +141,6 @@ class DocumentsCell: UITableViewCell {
         minutesButton.addTarget(self, action: #selector(minutesButtonTapped(sender:)), for: .touchUpInside)
         agendaButton.addTarget(self, action: #selector(agendaButtonTapped(sender:)), for: .touchUpInside)
     }
-    
     
     //MARK: - Actions
     @objc func minutesButtonTapped(sender: UIButton) {

--- a/publicmeetings-ios/Controllers/AboutViewController.swift
+++ b/publicmeetings-ios/Controllers/AboutViewController.swift
@@ -23,6 +23,7 @@ class AboutViewController: UIViewController {
         setupLayout()
     }
     
+   
     //MARK: - Setup and Layout
     private func setupView() {
         view.addSubview(aboutView)

--- a/publicmeetings-ios/Controllers/DocumentsViewController.swift
+++ b/publicmeetings-ios/Controllers/DocumentsViewController.swift
@@ -28,7 +28,7 @@ class DocumentsViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         setScreenTitle()
-        navigationController?.navigationBar.barTintColor = .systemPurple
+        navigationController?.navigationBar.barTintColor = .systemOrange
     }
     
     //MARK: - Setup and Layout

--- a/publicmeetings-ios/Controllers/MoreViewController.swift
+++ b/publicmeetings-ios/Controllers/MoreViewController.swift
@@ -31,7 +31,7 @@ class MoreViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     override func viewWillAppear(_ animated: Bool) {
         setScreenTitle()
-        navigationController?.navigationBar.barTintColor = .systemYellow
+        navigationController?.navigationBar.barTintColor = .systemOrange
     }
     
     //MARK: - TableView Delegates

--- a/publicmeetings-ios/Controllers/SearchViewController.swift
+++ b/publicmeetings-ios/Controllers/SearchViewController.swift
@@ -26,7 +26,7 @@ class SearchViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         setScreenTitle()
-        navigationController?.navigationBar.barTintColor = UIColor(named: "softRed")
+        navigationController?.navigationBar.barTintColor = .systemOrange
     }
     
     //MARK: - Setup and Layout


### PR DESCRIPTION
Change all the naviagation bar colors to systemOrange, so it's consistent across screens.
Update button background colors to tan.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/DocumentsCell.swift
	modified:   publicmeetings-ios/Controllers/AboutViewController.swift
	modified:   publicmeetings-ios/Controllers/DocumentsViewController.swift
	modified:   publicmeetings-ios/Controllers/MoreViewController.swift
	modified:   publicmeetings-ios/Controllers/SearchViewController.swift