### PR TITLE
Meeting Dates

### DIFF
--- a/publicmeetings-ios/Cells/MeetingCell.swift
+++ b/publicmeetings-ios/Cells/MeetingCell.swift
@@ -159,7 +159,7 @@ class MeetingCell: UITableViewCell {
             
             dateView.topAnchor.constraint(equalTo: view.topAnchor),
             dateView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            dateView.widthAnchor.constraint(equalToConstant: 80.0),
+            dateView.widthAnchor.constraint(equalToConstant: 90.0),
             dateView.heightAnchor.constraint(equalToConstant: 140.0),
             
             dateView.dayOfWeekLabel.topAnchor.constraint(equalTo: dateView.topAnchor),

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -68,13 +68,19 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell") as! MeetingCell
         let row = indexPath.row
         
+        let actualDate = convertToDate(stringDate: meetings[row].date)
+        print("actualDate: \(actualDate)")
+        
         cell.badgeDelegate = self
         cell.name.text = meetings[row].title
         cell.desc.text = meetings[row].description
         cell.address.text = meetings[row].address
         cell.location.text = meetings[row].location
         cell.city.text = meetings[row].cityState
-        cell.meetingDate.text = meetings[row].date
+        
+        cell.dateView.dayOfWeekLabel.text = actualDate.longDay
+        cell.dateView.dateLabel.text = actualDate.dateOfMonth
+        cell.dateView.monthLabel.text = actualDate.longMonth
 
         return cell
     }
@@ -252,5 +258,16 @@ extension MeetingsViewController {
         let mapItem = MKMapItem(placemark: placemark)
         mapItem.name = "City Hall"
         mapItem.openInMaps(launchOptions: options)
+    }
+    
+    
+    //NOTE: THIS IS A FAKE METHOD FOR TESTING ONLY!!!  DO NOT USE IN PRODUCTION CODE!!!
+    func convertToDate(stringDate: String) -> Date {
+        print("convertToDate: \(stringDate)")
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM-dd-yyyy"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX") // set locale to reliable US_POSIX
+        let date = dateFormatter.date(from: stringDate)!
+        return date
     }
 }

--- a/publicmeetings-ios/Extensions/DateExtension.swift
+++ b/publicmeetings-ios/Extensions/DateExtension.swift
@@ -9,6 +9,13 @@
 import Foundation
 
 extension Date {
+    var dateOfMonth: String {
+        let fmt  = DateFormatter()
+        fmt.dateFormat = "dd"
+        let date: String = fmt.string(from: self)
+        return date
+    }
+    
     var shortDate: String {
         let fmt  = DateFormatter()
         fmt.dateFormat = "MM-dd"

--- a/publicmeetings-ios/TabBar/TabBarController.swift
+++ b/publicmeetings-ios/TabBar/TabBarController.swift
@@ -49,8 +49,6 @@ class TabBarController: UITabBarController {
         UITabBar.appearance().unselectedItemTintColor = UIColor(named: "unselectedBlue")
         UITabBar.appearance().alpha = 1.0
         UITabBar.appearance().backgroundColor = UIColor(named: "devictBlue")
-        
-        
     }
 }
 

--- a/publicmeetings-ios/Views/DateView.swift
+++ b/publicmeetings-ios/Views/DateView.swift
@@ -15,7 +15,6 @@ class DateView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = Standard.systemFont
         label.textAlignment = .center
-        label.text = "Monday"
         label.textColor = .white
         return label
     }()
@@ -25,7 +24,6 @@ class DateView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = Standard.systemFontLarge
         label.textAlignment = .center
-        label.text = "30"
         label.textColor = .white
         return label
     }()
@@ -35,7 +33,6 @@ class DateView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = Standard.systemFont
         label.textAlignment = .center
-        label.text = "January"
         label.textColor = .white
         return label
     }()


### PR DESCRIPTION
Add method that will convert mock date from String format to a Date() format and then use that to separate into its component parts and display in the DateView on the meetings cell.

Note: When we have an actual data feed, this code will be converted to handle it.

Changes to be committed:
	modified:   publicmeetings-ios/Cells/MeetingCell.swift
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift
	modified:   publicmeetings-ios/Extensions/DateExtension.swift
	modified:   publicmeetings-ios/TabBar/TabBarController.swift
	modified:   publicmeetings-ios/Views/DateView.swift