### PR TITLE
Design Color

### DIFF
--- a/publicmeetings-ios/Colors.xcassets/softBlue.colorset/Contents.json
+++ b/publicmeetings-ios/Colors.xcassets/softBlue.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "59",
+          "red" : "67",
           "alpha" : "1.000",
-          "blue" : "196",
-          "green" : "155"
+          "blue" : "201",
+          "green" : "142"
         }
       }
     }

--- a/publicmeetings-ios/Controllers/MeetingsViewController.swift
+++ b/publicmeetings-ios/Controllers/MeetingsViewController.swift
@@ -15,7 +15,7 @@ class MeetingsViewController: UIViewController, UITableViewDelegate, UITableView
     var venue: UISegmentedControl = {
         let segmented = UISegmentedControl(items: ["All", "Wichita", "County", "State"])
         segmented.translatesAutoresizingMaskIntoConstraints = false
-        segmented.backgroundColor = UIColor.black
+        segmented.backgroundColor = UIColor(named: "softBlue")
         segmented.selectedSegmentIndex = 0
         segmented.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.black], for: UIControl.State.selected)
         segmented.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: UIControl.State.normal)


### PR DESCRIPTION
Add new color asset for a light blue and use for segmented control on meeting screen.

Changes to be committed:
	modified:   publicmeetings-ios/Colors.xcassets/softBlue.colorset/Contents.json
	modified:   publicmeetings-ios/Controllers/MeetingsViewController.swift