### PR TITLE
About

### DIFF
--- a/publicmeetings-ios/Views/AboutView.swift
+++ b/publicmeetings-ios/Views/AboutView.swift
@@ -35,6 +35,8 @@ class AboutView: UIView {
         textView.backgroundColor = .clear
         textView.textColor = .white
         textView.font = Standard.systemFont
+        textView.isEditable = false
+        textView.isSelectable = false
         return textView
     }()
     


### PR DESCRIPTION
Make the textview on the about screen uneditable and unselectable.

Changes to be committed:
	modified:   publicmeetings-ios/Views/AboutView.swift