### PR TITLE
About screen

### DIFF
--- a/publicmeetings-ios/Controllers/AboutViewController.swift
+++ b/publicmeetings-ios/Controllers/AboutViewController.swift
@@ -36,6 +36,7 @@ class AboutViewController: UIViewController, CloseButtonDelegate {
         
         closeButton.delegate = self
         closeButton.tintColor = .white
+        closeButton.setSystemImage(systemImage: "xmark")
     }
     
     private func setupLayout() {

--- a/publicmeetings-ios/Controllers/MoreViewController.swift
+++ b/publicmeetings-ios/Controllers/MoreViewController.swift
@@ -93,6 +93,7 @@ class MoreViewController: UIViewController, UITableViewDelegate, UITableViewData
             
             if currentItem == "About" {
                 let viewController = AboutViewController()
+                //viewController.modalPresentationStyle = .fullScreen
                 
                 DispatchQueue.main.async {
                     self.present(viewController, animated: true, completion: nil)

--- a/publicmeetings-ios/UtilityViews/CloseButton.swift
+++ b/publicmeetings-ios/UtilityViews/CloseButton.swift
@@ -38,6 +38,15 @@ class CloseButton: UIButton {
         addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }
     
+    //MARK: - Methods
+    func setSystemImage(systemImage: String) {
+        self.setImage(UIImage(systemName: systemImage), for: .normal)
+    }
+    
+    func setImage(image: String) {
+        self.setImage(UIImage(named: image), for: .normal)
+    }
+    
     //MARK: - Actions
     @objc func buttonTapped() {
         delegate?.closeButtonTapped()


### PR DESCRIPTION
Update the CloseButton class.  Add a method to set the systemImage and the "regular" image.  Setting the regular image is more a courtesey and just a wrapper around the setImage(_:) method that already exists for a UIButton.

I added the setSystemImage(_:) method so that it'd be easier to change the UI for different themes.

Changes to be committed:
	modified:   publicmeetings-ios/Controllers/AboutViewController.swift
	modified:   publicmeetings-ios/Controllers/MoreViewController.swift
	modified:   publicmeetings-ios/UtilityViews/CloseButton.swift