### PR TITLE
Apple sign-in - dismissal

### DIFF
--- a/publicmeetings-ios/Controllers/LoginViewController.swift
+++ b/publicmeetings-ios/Controllers/LoginViewController.swift
@@ -58,6 +58,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         //TODO: Proper error handling
         print("Error with Apple Authorization")
+        self.dismiss(animated: false, completion: nil)
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
@@ -67,6 +68,8 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
             default:
                 break
         }
+        
+        self.dismiss(animated: false, completion: nil)
     }
 }
 


### PR DESCRIPTION
The login is just a temporary view controller to test sign-in, but it wasn't dismissing, so I added a dismiss(_:) call.

Changes to be committed:
	modified:   publicmeetings-ios/Controllers/LoginViewController.swift